### PR TITLE
go-kosu: uses private key from ~/.kosu

### DIFF
--- a/packages/go-kosu/abci/app_test.go
+++ b/packages/go-kosu/abci/app_test.go
@@ -17,7 +17,8 @@ func newTestApp(t *testing.T, db db.DB) (func(), *App) {
 	dir, err := ioutil.TempDir("", ".kosu_tests_")
 	require.NoError(t, err)
 
-	InitTendermint(dir)
+	err = InitTendermint(dir)
+	require.NoError(t, err)
 
 	fn := func() { _ = os.RemoveAll(dir) }
 	return fn, NewApp(store.NewState(), db, dir)

--- a/packages/go-kosu/abci/cli/tx.go
+++ b/packages/go-kosu/abci/cli/tx.go
@@ -38,7 +38,8 @@ func (cli *CLI) RebalanceTx() *cobra.Command {
 
 			res, err := cli.client.BroadcastTxCommit(tx)
 			if err != nil {
-				return err
+				fmt.Printf("%v\n", err)
+				os.Exit(1)
 			}
 
 			if res.CheckTx.IsErr() {

--- a/packages/go-kosu/abci/setup.go
+++ b/packages/go-kosu/abci/setup.go
@@ -14,14 +14,12 @@ import (
 var chainIDPrefix = "kosu-chain-%v"
 
 // InitTendermint creates an initial tendermint file structure
-func InitTendermint(homedir string) {
+func InitTendermint(homedir string) error {
 	if homedir == "" {
 		homedir = DefaultHomeDir
 	}
 
-	if err := createConfig(homedir); err != nil {
-		panic(err)
-	}
+	return createConfig(homedir)
 }
 
 // Code from tendermint init...

--- a/packages/go-kosu/cmd/kosu-cli/main.go
+++ b/packages/go-kosu/cmd/kosu-cli/main.go
@@ -4,31 +4,40 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"go-kosu/abci"
 	"go-kosu/abci/cli"
-	"go-kosu/abci/types"
 )
 
 func main() {
 	var client abci.Client
-
-	_, privKey, err := types.NewKeyPair()
-	if err != nil {
-		panic(err)
-	}
 
 	rootCmd := &cobra.Command{
 		Use:   "kosu-cli",
 		Short: "kosu console client",
 	}
 	rootCmd.PersistentFlags().String("abci", "http://localhost:26657", "ABCI server url")
-	rootCmd.PersistentFlags().String("key", hex.EncodeToString(privKey), "Private key")
+	rootCmd.PersistentFlags().String("home", "~/.kosu", "directory for config and data")
+	rootCmd.PersistentFlags().String("key", "", "Private key. Overrides the private key loaded from --home dir")
 	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		key := cmd.Flag("key").Value.String()
-		dec, err := hex.DecodeString(key)
+		var (
+			err error
+			key []byte
+		)
+
+		keyFlag := cmd.Flag("key")
+		if keyFlag.Changed {
+			val := keyFlag.Value.String()
+			key, err = hex.DecodeString(val)
+		} else {
+			home := cmd.Flag("home").Value.String()
+			key, err = abci.LoadPrivateKey(expandPath(home))
+		}
 		if err != nil {
 			return err
 		}
@@ -36,7 +45,7 @@ func main() {
 		addr := cmd.Flag("abci").Value.String()
 
 		// update the client
-		client = *abci.NewHTTPClient(addr, dec)
+		client = *abci.NewHTTPClient(addr, key)
 		return nil
 	}
 
@@ -49,4 +58,19 @@ func main() {
 		fmt.Printf("%+v", err)
 		os.Exit(1)
 	}
+}
+
+func expandPath(path string) string {
+	usr, err := user.Current()
+	if err != nil {
+		return path
+	}
+
+	if path == "~" {
+		return usr.HomeDir
+	} else if strings.HasPrefix(path, "~/") {
+		return filepath.Join(usr.HomeDir, path[2:])
+	}
+
+	return path
 }

--- a/packages/go-kosu/tests/rebalance_test.go
+++ b/packages/go-kosu/tests/rebalance_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *Suite) TestRebalance() {
-	GivenABCIServer(s.T(), s.state, func(t *testing.T) {
+	GivenABCIServer(s.T(), s, func(t *testing.T) {
 		Convey("And an 'Initial rebalance period = 0' state", func() {
 			s.state.RoundInfo = store.RoundInfo{}
 

--- a/packages/go-kosu/tests/suite_test.go
+++ b/packages/go-kosu/tests/suite_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"go-kosu/abci"
-	"go-kosu/abci/types"
 	"go-kosu/store"
 
 	"github.com/stretchr/testify/suite"
@@ -13,14 +12,4 @@ type Suite struct {
 
 	state  *store.State
 	client *abci.Client
-}
-
-func (s *Suite) SetupTest() {
-	_, privKey, err := types.NewKeyPair()
-	if err != nil {
-		s.Require().NoError(err)
-	}
-
-	s.state = store.NewState()
-	s.client = abci.NewHTTPClient("http://localhost:26657", privKey)
 }

--- a/packages/go-kosu/tests/support.go
+++ b/packages/go-kosu/tests/support.go
@@ -15,29 +15,38 @@ import (
 )
 
 // GivenABCIServer a ABCI Server inside a Convey block
-func GivenABCIServer(t *testing.T, state *store.State, fn func(t *testing.T)) {
+func GivenABCIServer(t *testing.T, suite *Suite, fn func(*testing.T)) {
+	if suite.state == nil {
+		suite.state = store.NewState()
+	}
+
 	convey.Convey("Given an ABCI Server", t, func() {
-		closer := startServer(t, db.NewMemDB(), state)
+		app, closer := startServer(t, db.NewMemDB(), suite.state)
 		defer closer()
+
+		key, err := abci.LoadPrivateKey(app.Config.RootDir)
+		require.NoError(t, err)
+
+		suite.client = abci.NewHTTPClient("http://localhost:26657", key)
 		fn(t)
 	})
 }
 
-func startServer(t *testing.T, db db.DB, state *store.State) func() {
+func startServer(t *testing.T, db db.DB, state *store.State) (*abci.App, func()) {
 	// Create a temp dir and initialize tendermint there
 	dir, err := ioutil.TempDir("/tmp", "/go-kosu-go-tests_")
 	require.NoError(t, err)
 
-	abci.InitTendermint(dir)
+	err = abci.InitTendermint(dir)
+	require.NoError(t, err)
 
 	// Initialize the server
 	app := abci.NewApp(state, db, dir)
-
 	srv, err := abci.StartInProcessServer(app)
 	require.NoError(t, err)
 
 	// nolint
-	return func() {
+	return app, func() {
 		srv.Stop()
 		os.RemoveAll(dir)
 	}

--- a/packages/go-kosu/tests/witness_test.go
+++ b/packages/go-kosu/tests/witness_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"encoding/hex"
 	"testing"
 	"time"
 
@@ -16,7 +15,7 @@ import (
 )
 
 func (s *Suite) TestWitnessTx() {
-	GivenABCIServer(s.T(), s.state, func(t *testing.T) {
+	GivenABCIServer(s.T(), s, func(t *testing.T) {
 		s.state.LastEvent = 10
 
 		tx := &types.TransactionWitness{
@@ -71,7 +70,7 @@ func (s *Suite) TestWitnessTx() {
 }
 
 func (s *Suite) TestWitnessRebalance() {
-	GivenABCIServer(s.T(), s.state, func(t *testing.T) {
+	GivenABCIServer(s.T(), s, func(t *testing.T) {
 		tx := &types.TransactionRebalance{
 			RoundInfo: &types.RoundInfo{},
 		}
@@ -79,7 +78,7 @@ func (s *Suite) TestWitnessRebalance() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		w := startWitness(t)
+		w := startWitness(t, s.client)
 		err := w.Start(ctx)
 		require.NoError(t, err)
 
@@ -101,12 +100,9 @@ func (s *Suite) TestWitnessRebalance() {
 	})
 }
 
-func startWitness(t *testing.T) *witness.Witness {
-	strKey := "0F8C50DC955DA31B617D5F0702511528F824027A30ED1CF33496D455D840EF1C9D3E50B8B5B1745747FEAFE6C43A11703FEE3F2B9D14E6234F03B60A6BB6ACD9" //nolint
-	key, _ := hex.DecodeString(strKey)
-	client := abci.NewHTTPClient("tcp://0.0.0.0:26657", key)
+func startWitness(t *testing.T, c *abci.Client) *witness.Witness {
 	p, err := witness.NewEthereumProvider("wss://ropsten.infura.io/ws")
 	require.NoError(t, err)
 
-	return witness.New(client, p)
+	return witness.New(c, p)
 }


### PR DESCRIPTION
# Overview
Uses the private key from ~/.kosu/config/priv_validator.json instead of a random one.

# Description
We were generating a new private key each time we ran `./kosud` or `./kosu-cli` if not specified. With these changes `kosud` will only use the key from `./kosu`, `kosu-cli` can either specify one or defaults to `~/.kosu/`