### PR TITLE
go-kosu: Better logger

### DIFF
--- a/packages/go-kosu/abci/node.go
+++ b/packages/go-kosu/abci/node.go
@@ -11,10 +11,6 @@ import (
 	"github.com/tendermint/tendermint/proxy"
 )
 
-var (
-	logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "main")
-)
-
 // CreateNode creates an embedded tendermint node for standalone mode
 func (app *App) CreateNode() (*node.Node, error) {
 	// Assumes priv validator has been generated.  See setup()
@@ -23,7 +19,17 @@ func (app *App) CreateNode() (*node.Node, error) {
 		return nil, err
 	}
 
-	logger, err := tmflags.ParseLogLevel(app.Config.LogLevel, log.NewTMLogger(os.Stdout), app.Config.LogFormat)
+	var w log.Logger
+	switch app.Config.LogFormat {
+	case "json":
+		w = log.NewTMJSONLogger(os.Stdout)
+	case "", "plain":
+		w = log.NewTMLogger(os.Stdout)
+	case "none":
+		w = log.NewNopLogger()
+	}
+
+	logger, err := tmflags.ParseLogLevel(app.Config.LogLevel, w, "error")
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-kosu/abci/setup.go
+++ b/packages/go-kosu/abci/setup.go
@@ -2,9 +2,11 @@ package abci
 
 import (
 	"fmt"
+	"os"
 
 	cfg "github.com/tendermint/tendermint/config"
 	cmn "github.com/tendermint/tendermint/libs/common"
+	log "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/types"
@@ -13,17 +15,23 @@ import (
 
 var chainIDPrefix = "kosu-chain-%v"
 
-// InitTendermint creates an initial tendermint file structure
+// InitTendermint creates an initial tendermint file structure.
 func InitTendermint(homedir string) error {
+	logger := log.NewTMLogger(log.NewSyncWriter(os.Stdout)).With("module", "main")
+	return InitTendermintWithLogger(homedir, logger)
+}
+
+// InitTendermintWithLogger creates an initial tendermint file structure using a custom logger.
+func InitTendermintWithLogger(homedir string, logger log.Logger) error {
 	if homedir == "" {
 		homedir = DefaultHomeDir
 	}
 
-	return createConfig(homedir)
+	return createConfig(homedir, logger)
 }
 
 // Code from tendermint init...
-func createConfig(homedir string) error {
+func createConfig(homedir string, logger log.Logger) error {
 	config := cfg.DefaultConfig()
 	if homedir == "" {
 		config.SetRoot(DefaultHomeDir)

--- a/packages/go-kosu/tests/support.go
+++ b/packages/go-kosu/tests/support.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/db"
+	"github.com/tendermint/tendermint/libs/log"
 
 	"go-kosu/abci"
 	"go-kosu/store"
@@ -37,11 +38,12 @@ func startServer(t *testing.T, db db.DB, state *store.State) (*abci.App, func())
 	dir, err := ioutil.TempDir("/tmp", "/go-kosu-go-tests_")
 	require.NoError(t, err)
 
-	err = abci.InitTendermint(dir)
+	err = abci.InitTendermintWithLogger(dir, log.NewNopLogger())
 	require.NoError(t, err)
 
 	// Initialize the server
 	app := abci.NewApp(state, db, dir)
+	app.Config.LogFormat = "none"
 	srv, err := abci.StartInProcessServer(app)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Integration tests were hard to read, because there were no way to
controll the output of `InitTendermint`, also, we were ignoring the
value of log format.

InitTendermintWithLogger has been introduced as well as "json" and
"none" logger config.
