### PR TITLE
Fixing yarn install warnings (incorrect peer dependency)

### DIFF
--- a/packages/kosu-system-contracts/package.json
+++ b/packages/kosu-system-contracts/package.json
@@ -44,6 +44,7 @@
         "@0x/web3-wrapper": "^6.0.5",
         "@kosu/subcontract-sdk": "0.1.0-alpha.1",
         "@kosu/tslint-config": "^0.0.4",
+        "bitcore-lib": "0.16",
         "ethereum-types": "^2.1.2",
         "openzeppelin-solidity": "2.1.2",
         "safe-node-require": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3406,6 +3406,18 @@ bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
+bitcore-lib@0.16, bitcore-lib@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-0.16.0.tgz#a2c3ec1108cdb90386f728282ab833e0c77c9533"
+  integrity sha512-CEtcrPAH2gwgaMN+OPMJc18TBEak1+TtzMyafrqrIbK9PIa3kat195qBJhC0liJSHRiRr6IE2eLcXeIFFs+U8w==
+  dependencies:
+    bn.js "=4.11.8"
+    bs58 "=4.0.1"
+    buffer-compare "=1.1.1"
+    elliptic "=6.4.0"
+    inherits "=2.0.1"
+    lodash "=4.17.11"
+
 bitcore-lib@^0.15.0:
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-0.15.0.tgz#f924be13869f2aab7e04aeec5642ad3359b6cec2"
@@ -3417,18 +3429,6 @@ bitcore-lib@^0.15.0:
     elliptic "=6.4.0"
     inherits "=2.0.1"
     lodash "=4.17.4"
-
-bitcore-lib@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-0.16.0.tgz#a2c3ec1108cdb90386f728282ab833e0c77c9533"
-  integrity sha512-CEtcrPAH2gwgaMN+OPMJc18TBEak1+TtzMyafrqrIbK9PIa3kat195qBJhC0liJSHRiRr6IE2eLcXeIFFs+U8w==
-  dependencies:
-    bn.js "=4.11.8"
-    bs58 "=4.0.1"
-    buffer-compare "=1.1.1"
-    elliptic "=6.4.0"
-    inherits "=2.0.1"
-    lodash "=4.17.11"
 
 bitcore-mnemonic@^1.5.0:
   version "1.7.0"


### PR DESCRIPTION
## Overview

- `yarn` emitting warnings due to a incorrect dependency in `@0x/subproviders`
- fixed by adding `bitcore-lib` as a direct dependency of `kosu-system-contracts` at the correct version