### PR TITLE
uising node image instead of yarn

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -51,9 +51,11 @@ steps:
  # GENERATE DOCS
  # =============
 
-- name: "gcr.io/cloud-builders/yarn"
+- name: node:10.15.1
+  entrypoint: yarn
   args: ["install"]
-- name: "gcr.io/cloud-builders/yarn"
+- name: node:10.15.1
+  entrypoint: yarn
   args: ["docs"]
 
 # =============


### PR DESCRIPTION
## Overview

- Using `node` image for cloud-build rather than `yarn`