### PR TITLE
cd: fixing cloud-build doc config

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,9 +2,9 @@
 
 steps:
 
- # ===============
- # BUILD CI IMAGES
- # ===============
+# ===============
+# BUILD CI IMAGES
+# ===============
 
 # Pull images to build from cache
 - name: 'gcr.io/cloud-builders/docker'
@@ -47,9 +47,9 @@ steps:
     "./packages/kosu-geth"
   ]
 
- # =============
- # GENERATE DOCS
- # =============
+# =============
+# GENERATE DOCS
+# =============
 
 - name: node:10.15.1
   entrypoint: yarn
@@ -58,6 +58,28 @@ steps:
 - name: node:10.15.1
   entrypoint: yarn
   args: ["docs"]
+
+# ===========
+# UPLOAD DOCS
+# ===========
+
+- name: "gcr.io/cloud-builders/gsutil"
+  args: [
+    "-m", 
+    "rsync", 
+    "-r", "-c", "-d", 
+    "./packages/kosu.js/docs/",
+    "gs://kosu-docs/kosu.js/"
+  ]
+
+- name: "gcr.io/cloud-builders/gsutil"
+  args: [
+    "-m", 
+    "rsync", 
+    "-r", "-c", "-d", 
+    "./packages/kosu-system-contracts/docs/",
+    "gs://kosu-docs/kosu-system-contracts/"
+  ]
 
 # =============
 # DOCKER IMAGES
@@ -73,19 +95,6 @@ images: [
   # kosu-geth poa test image
   "gcr.io/kosu-io/kosu-geth:$SHORT_SHA", "gcr.io/kosu-io/kosu-geth:latest",
 ]
-
-# ====================
-# SAVE DOCS & BINARIES
-# ====================
-
-artifacts: 
-  objects:
-    location: "gs://kosu-docs/kosu.js/"
-    paths: ["packages/kosu.js/docs/**/*.*"]
-  
-  objects:
-    location: "gs://kosu-docs/kosu-system-contracts/"
-    paths: ["packages/kosu-system-contracts/docs/**/*.*"]
 
 # ======
 # CONFIG


### PR DESCRIPTION
## Overview

Generated docs (`kosu.js` and `kosu-system-contracts`, for now) being stored in `gs://kosu-docs` each commit to master.