### PR TITLE
cloudbuild: move kosu binary storage location

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,15 +193,23 @@ Pre-built binaries for `go-kosu` are available (per-commit CD builds are current
 
 ### `kosud`
 
-Kosu network client reference implementation, built on Tendermint consensus.
+Kosu network client reference implementation, built on Tendermint consensus. Run `kosud --help` for usage.
 
--   URL: [`https://storage.googleapis.com/kosu-binaries/go-kosu/kosud`](https://storage.googleapis.com/kosu-binaries/go-kosu/kosud)
+```
+wget https://storage.googleapis.com/kosud/linux_amd64/kosud
+chmod +x kosud
+install kosud /usr/local/bin
+```
 
 ### `kosu-cli`
 
-Command-line interface for `kosud`.
+Command-line interface for `kosud` (run `kosu-cli` for usage).
 
--   URL: [`https://storage.googleapis.com/kosu-binaries/go-kosu/kosu-cli`](https://storage.googleapis.com/kosu-binaries/go-kosu/kosu-cli)
+```
+wget https://storage.googleapis.com/kosu-cli/linux_amd64/kosu-cli
+chmod +x kosu-cli
+install kosu-cli /usr/local/bin
+```
 
 ## Contributing
 

--- a/cloudbuild/main.yaml
+++ b/cloudbuild/main.yaml
@@ -53,7 +53,7 @@ steps:
     "-m",
     "cp", 
     "./packages/go-kosu/kosud",
-    "gs://kosu-binaries/go-kosu/",
+    "gs://kosud/linux_amd64/",
   ]
 
 - name: "gcr.io/cloud-builders/gsutil"
@@ -61,7 +61,7 @@ steps:
     "-m",
     "cp", 
     "./packages/go-kosu/kosu-cli",
-    "gs://kosu-binaries/go-kosu/",
+    "gs://kosu-cli/linux_amd64/",
   ]
 
 # ================


### PR DESCRIPTION
## Overview 

Moving GCP bucket that per-commit `kosud` and `kosu-cli` binaries are published to. 