### PR TITLE
go-kosu: eth connection retry

### DIFF
--- a/packages/go-kosu/witness/eth.go
+++ b/packages/go-kosu/witness/eth.go
@@ -78,6 +78,9 @@ func (w *EthereumProvider) backoff(name string, fn func() error) error {
 
 	for {
 		err := fn()
+		if err == context.Canceled || err == context.DeadlineExceeded {
+			return err
+		}
 
 		w.log.Error("Watcher: retrying...", "op", name, "err", err, "in", delay)
 		time.Sleep(delay)


### PR DESCRIPTION
## Overview
When the connection with Ethereum blockchain is lost, the witness does not retry, thus is lost forever.

## Description
A simple exponential backoff has been implemented in order to keep retrying until connection succeeds.