### PR TITLE
cloudbuild: using updated node-ci image for main cd build

### DIFF
--- a/cloudbuild/main.yaml
+++ b/cloudbuild/main.yaml
@@ -6,11 +6,11 @@ steps:
 # INSTALL AND BUILD
 # =================
 
-- name: gcr.io/kosu-io/node-lts:latest
+- name: gcr.io/kosu-io/node-ci:latest
   entrypoint: yarn
   args: ["install"]
 
-- name: gcr.io/kosu-io/node-lts:latest
+- name: gcr.io/kosu-io/node-ci:latest
   entrypoint: yarn
   args: ["build"]
 
@@ -18,7 +18,7 @@ steps:
 # BUILD DOCS
 # ==========
 
-- name: gcr.io/kosu-io/node-lts:latest
+- name: gcr.io/kosu-io/node-ci:latest
   entrypoint: yarn
   args: ["docs"]
 
@@ -86,7 +86,7 @@ steps:
     "./packages/kosu-docs/docs/kosu-system-contracts"
   ]
 
-- name: "gcr.io/kosu-io/node-lts:latest"
+- name: "gcr.io/kosu-io/node-ci:latest"
   entrypoint: "yarn"
   args: [
     "lerna", 


### PR DESCRIPTION
## Overview

Remove reference to old `node-lts` image in main cloud build. New `node-ci` can be used now that it is equivalent to what `node-lts` was prior to #162. 