### PR TITLE
kosu.js: force strict web3 versioning

### DIFF
--- a/packages/kosu.js/package.json
+++ b/packages/kosu.js/package.json
@@ -38,9 +38,9 @@
         "isomorphic-ws": "^4.0.1",
         "node-fetch": "^2.2.0",
         "web3": "1.0.0-beta.37",
-        "web3-eth-contract": "^1.0.0-beta.53",
-        "web3-provider-engine": "^15.0.0",
-        "web3-utils": "^1.0.0-beta.53",
+        "web3-eth-contract": "1.0.0-beta.53",
+        "web3-provider-engine": "15.0.0",
+        "web3-utils": "1.0.0-beta.53",
         "ws": "^6.1.4"
     },
     "devDependencies": {


### PR DESCRIPTION
## Overview

- Force specific web3 versions to avoid npm errors