### PR TITLE
Go kosu/rpc orders

### DIFF
--- a/packages/go-kosu/rpc/service.go
+++ b/packages/go-kosu/rpc/service.go
@@ -113,6 +113,7 @@ url -X POST localhost:14341 \
 	-H 'Content-Type: application/json'
 ```
 */
+// nolint:lll
 func (s *Service) AddOrders(orders []*types.TransactionOrder) error {
 	for _, order := range orders {
 		res, err := s.abci.BroadcastTxSync(order)


### PR DESCRIPTION
This adds the `kosu_addOrders` RPC method, also adds `cURL` example usage, which eventually could be moved to the `overview` docs