### PR TITLE
go-kosu: fixing witness issues

### DIFF
--- a/packages/go-kosu/witness/witness.go
+++ b/packages/go-kosu/witness/witness.go
@@ -162,7 +162,10 @@ func (w *Witness) broadcastTxSync(tx interface{}, args []interface{}) {
 
 func (w *Witness) handlePosterRegistryUpdate(e *EventEmitterKosuEvent) {
 	// offset by 12 because the 20 byte address is packed into 32 bytes
-	address, _ := store.NewAddress(e.Data[0][12:])
+	address, err := store.NewAddress(e.Data[0][12:])
+	if err != nil {
+		panic(err)
+	}
 
 	tx := &types.TransactionWitness{
 		Subject: types.TransactionWitness_POSTER,


### PR DESCRIPTION
## Overview

Fixing three small issues in the Witness.

## Description

While working on the Explore API server and `kosu.js` Go-Kosu client, I noticed a few weird things via the RPC server that indicated underlying errors, all of which occurred in the witness.

### 1. Rebalance periods skip 10 blocks

I noticed this:
```
> kosu.node.roundInfo().then(console.log)
> { number: 89, limit: 10, startsAt: 1976, endsAt: 1986 }
> kosu.node.roundInfo().then(console.log)
> { number: 90, limit: 10, startsAt: 1996, endsAt: 2006 }
```

Round `90` should have had `startsAt: 1986` and `endsAt: 1996`. The reason for this error was `rebalance` was being called with the _current_ Ethereum block, not the _matured_ Ethereum block, causing the 10 block discrepancy. This is now fixed. 

### 2. Poster accounts not associated with the right address

After registering a poster account, I was able to see the account was created with `kosu_numberPosters`, but unable to query it with `kosu_queryPoster`. After adding some log statements, I noticed the address being associated with the account was not my address, and was one I did not reckognize.

The source of the failure was the `TransactionWitness` TX was being created in the Witness with the `Address` of the _contract that emitted the event_, not the address contained within the event data. Certainly easy to miss, and now should be fixed.

### 3. Validator Ethereum addresses being padded

In a similar vein to the above issue, I noticed validator objects were being sent over (from `kosu_queryValidator`) like this:

```js
{ 
  balance: 500000000000000000000,
  power: 500,
  publicKey: 'wy9oIwzlO+KEItHZvvA9H9MnfqZNnO1bghLVZUgpJX8=',
  ethAccount:
   '000000000000000000000000c521f483f607eb5ea4d6b2dfdbd540134753a865',
  firstVote: 2319,
  lastVoted: 2320,
  lastProposed: 2321,
  totalVotes: 3,
  active: true,
  applied: true 
}
```

As you can see, there is 12 bytes of padding on the `ethAccount` that shouldn't be there. This was because all event data from the `KosuEvent` is padded to 32 bytes, so the first 12 empty bytes just need to be stripped off.

## Notes

@gchaincl let me know what you think of these changes, and if you would approach any of them differently than I did.