### PR TITLE
go-kosu: use full path imports

### DIFF
--- a/packages/go-kosu/abci/app.go
+++ b/packages/go-kosu/abci/app.go
@@ -16,9 +16,9 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	db "github.com/tendermint/tm-db"
 
-	"go-kosu/abci/types"
-	"go-kosu/store"
-	"go-kosu/store/cosmos"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store/cosmos"
 )
 
 var (

--- a/packages/go-kosu/abci/app_test.go
+++ b/packages/go-kosu/abci/app_test.go
@@ -14,7 +14,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 	db "github.com/tendermint/tm-db"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 func newTestApp(t *testing.T, db db.DB) (func(), *App) {

--- a/packages/go-kosu/abci/cli/cli.go
+++ b/packages/go-kosu/abci/cli/cli.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"go-kosu/abci"
-	"go-kosu/abci/types"
 	"os"
 	"strconv"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/spf13/cobra"
 )

--- a/packages/go-kosu/abci/client.go
+++ b/packages/go-kosu/abci/client.go
@@ -10,8 +10,8 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"go-kosu/abci/types"
-	"go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 )
 
 var (

--- a/packages/go-kosu/abci/genesis.go
+++ b/packages/go-kosu/abci/genesis.go
@@ -6,7 +6,7 @@ import (
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 // Genesis is the initial chain state

--- a/packages/go-kosu/abci/order.go
+++ b/packages/go-kosu/abci/order.go
@@ -1,8 +1,8 @@
 package abci
 
 import (
-	"go-kosu/abci/types"
-	"go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )

--- a/packages/go-kosu/abci/order_test.go
+++ b/packages/go-kosu/abci/order_test.go
@@ -3,12 +3,13 @@ package abci
 
 import (
 	"encoding/json"
-	"go-kosu/store"
 	"math/big"
 	"strings"
 	"testing"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/packages/go-kosu/abci/rebalance.go
+++ b/packages/go-kosu/abci/rebalance.go
@@ -1,9 +1,10 @@
 package abci
 
 import (
-	"go-kosu/abci/types"
 	"math"
 	"math/big"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 )

--- a/packages/go-kosu/abci/rebalance_test.go
+++ b/packages/go-kosu/abci/rebalance_test.go
@@ -4,7 +4,7 @@ import (
 	"math/big"
 	"testing"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/packages/go-kosu/abci/setup.go
+++ b/packages/go-kosu/abci/setup.go
@@ -13,7 +13,7 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 	tmtime "github.com/tendermint/tendermint/types/time"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 var chainIDPrefix = "kosu-chain-%v"

--- a/packages/go-kosu/abci/tags.go
+++ b/packages/go-kosu/abci/tags.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/tendermint/tendermint/libs/common"
 
-	"go-kosu/abci/types"
-	"go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 )
 
 // NewTagsFromRoundInfo returns a set of KVPair tags given a state.RoundInfo

--- a/packages/go-kosu/abci/types/types.pb.go
+++ b/packages/go-kosu/abci/types/types.pb.go
@@ -5,8 +5,9 @@ package types
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/packages/go-kosu/abci/witness.go
+++ b/packages/go-kosu/abci/witness.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"math/big"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/crypto/tmhash"

--- a/packages/go-kosu/abci/witness_test.go
+++ b/packages/go-kosu/abci/witness_test.go
@@ -1,9 +1,10 @@
 package abci
 
 import (
-	"go-kosu/abci/types"
 	"log"
 	"testing"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/packages/go-kosu/cmd/kosu-cli/main.go
+++ b/packages/go-kosu/cmd/kosu-cli/main.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"go-kosu/abci"
-	"go-kosu/abci/cli"
-	"go-kosu/version"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/cli"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/version"
 )
 
 func main() {

--- a/packages/go-kosu/cmd/kosud/main.go
+++ b/packages/go-kosu/cmd/kosud/main.go
@@ -14,10 +14,10 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	db "github.com/tendermint/tm-db"
 
-	"go-kosu/abci"
-	"go-kosu/rpc"
-	"go-kosu/version"
-	"go-kosu/witness"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/rpc"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/version"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/witness"
 )
 
 const (

--- a/packages/go-kosu/go.mod
+++ b/packages/go-kosu/go.mod
@@ -1,4 +1,4 @@
-module go-kosu
+module github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu
 
 go 1.12
 

--- a/packages/go-kosu/rpc/cmd.go
+++ b/packages/go-kosu/rpc/cmd.go
@@ -3,10 +3,11 @@ package rpc
 import (
 	"errors"
 	"fmt"
-	"go-kosu/abci"
 	"log"
 	"net/http"
 	"sync"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/spf13/cobra"

--- a/packages/go-kosu/rpc/rpc.go
+++ b/packages/go-kosu/rpc/rpc.go
@@ -1,7 +1,7 @@
 package rpc
 
 import (
-	"go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
 
 	"github.com/ethereum/go-ethereum/rpc"
 )

--- a/packages/go-kosu/rpc/rpc_test.go
+++ b/packages/go-kosu/rpc/rpc_test.go
@@ -9,9 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go-kosu/abci"
-	"go-kosu/abci/types"
-	"go-kosu/tests"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/tests"
 
 	db "github.com/tendermint/tm-db"
 )

--- a/packages/go-kosu/rpc/service.go
+++ b/packages/go-kosu/rpc/service.go
@@ -3,10 +3,11 @@ package rpc
 import (
 	"context"
 	"encoding/hex"
-	"go-kosu/abci"
-	"go-kosu/abci/types"
 	"log"
 	"strings"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/ethereum/go-ethereum/rpc"
 
@@ -225,7 +226,7 @@ _Returns:_
 #### Go Example
 
 ```go
-orders := make(chan types.TransactionOrder) // imported from go-kosu/abci/types
+orders := make(chan types.TransactionOrder) // imported from github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types
 ctx := context.Background()
 sub, err := client.Subscribe(ctx, "kosu", orders, "subscribe", "newOrders")
 if err != nil {
@@ -345,7 +346,7 @@ _Returns:_
 #### Go Example
 
 ```go
-rs := make(chan types.TransactionRebalance) // imported from go-kosu/abci/types
+rs := make(chan types.TransactionRebalance) // imported from github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types
 ctx := context.Background()
 sub, err := client.Subscribe(ctx, "kosu", orders, "subscribe", "newRebalances")
 if err != nil {

--- a/packages/go-kosu/store/cosmos/store.go
+++ b/packages/go-kosu/store/cosmos/store.go
@@ -10,8 +10,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/store/rootmulti"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"go-kosu/abci/types"
-	"go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 )
 
 // Store stores the application state

--- a/packages/go-kosu/store/cosmos/store_test.go
+++ b/packages/go-kosu/store/cosmos/store_test.go
@@ -3,8 +3,8 @@ package cosmos
 import (
 	"testing"
 
-	"go-kosu/store"
-	"go-kosu/store/storetest"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store/storetest"
 
 	db "github.com/tendermint/tm-db"
 )

--- a/packages/go-kosu/store/order.go
+++ b/packages/go-kosu/store/order.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go-kosu/abci/types"
 	"math/big"
 	"strings"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/packages/go-kosu/store/order_test.go
+++ b/packages/go-kosu/store/order_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"go-kosu/abci/types"
 	"strings"
 	"testing"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/packages/go-kosu/store/store.go
+++ b/packages/go-kosu/store/store.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/store"
 
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 // Store stores the application state

--- a/packages/go-kosu/store/storetest/testing.go
+++ b/packages/go-kosu/store/storetest/testing.go
@@ -1,10 +1,11 @@
 package storetest
 
 import (
-	"go-kosu/abci/types"
-	"go-kosu/store"
 	"math"
 	"testing"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/packages/go-kosu/tests/order_test.go
+++ b/packages/go-kosu/tests/order_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"go-kosu/abci/types"
-	"go-kosu/rpc"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/rpc"
 
 	"github.com/stretchr/testify/require"
 )

--- a/packages/go-kosu/tests/rebalance_test.go
+++ b/packages/go-kosu/tests/rebalance_test.go
@@ -1,7 +1,7 @@
 package tests
 
 import (
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 func (suite *IntegrationTestSuite) TestRebalance() {

--- a/packages/go-kosu/tests/suite_test.go
+++ b/packages/go-kosu/tests/suite_test.go
@@ -16,8 +16,8 @@ import (
 	rpctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 
-	"go-kosu/abci"
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 func init() {

--- a/packages/go-kosu/tests/support.go
+++ b/packages/go-kosu/tests/support.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	db "github.com/tendermint/tm-db"
 
-	"go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
 )
 
 // StartServer starts a kosud test server.

--- a/packages/go-kosu/tests/validators_test.go
+++ b/packages/go-kosu/tests/validators_test.go
@@ -2,7 +2,8 @@ package tests
 
 import (
 	"encoding/hex"
-	"go-kosu/abci/types"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 func (suite *IntegrationTestSuite) TestValidators() {

--- a/packages/go-kosu/tests/witness_test.go
+++ b/packages/go-kosu/tests/witness_test.go
@@ -1,8 +1,8 @@
 package tests
 
 import (
-	"go-kosu/abci"
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 func (suite *IntegrationTestSuite) TestWitness() {

--- a/packages/go-kosu/version/version.go
+++ b/packages/go-kosu/version/version.go
@@ -2,15 +2,16 @@ package version
 
 import (
 	"fmt"
-	"go-kosu/rpc"
 	"runtime"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/rpc"
 
 	"github.com/tendermint/tendermint/version"
 )
 
 // These flags are passed at compile time as follows:
-//   go build -ldflags "-X go-kosu/version.Version=1.0 \
-//                      -X go-kosu/version.GitCommit=sha"
+//   go build -ldflags "-X github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/version.Version=1.0 \
+//                      -X github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/version.GitCommit=sha"
 var (
 	Version   = "<dev>"
 	GitCommit = "<N/A>"

--- a/packages/go-kosu/witness/event_decoder.go
+++ b/packages/go-kosu/witness/event_decoder.go
@@ -3,8 +3,9 @@ package witness
 import (
 	"errors"
 	"fmt"
-	"go-kosu/store"
 	"math/big"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
 )
 
 // EventPosterRegistryUpdate represent a decoded PosterRegistryUpdate event

--- a/packages/go-kosu/witness/witness.go
+++ b/packages/go-kosu/witness/witness.go
@@ -9,8 +9,8 @@ import (
 	eth "github.com/ethereum/go-ethereum/core/types"
 	"github.com/tendermint/tendermint/libs/log"
 
-	"go-kosu/abci"
-	"go-kosu/abci/types"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 )
 
 // EventHandler is a callback that handles EventEmitterKosuEvent


### PR DESCRIPTION
This updates the local imports to full path:
`import `~`go-kosu/witness `~`github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/witness`

This is only useful to keep godoc.org references working