### PR TITLE
fix frozen subscriptions

### DIFF
--- a/packages/go-kosu/abci/client.go
+++ b/packages/go-kosu/abci/client.go
@@ -101,16 +101,8 @@ func (c *Client) Subscribe(ctx context.Context, q string) (<-chan rpctypes.Resul
 		return nil, nil, err
 	}
 
-	closer := func() {
-		_ = c.Client.Unsubscribe(ctx, "kosu", q)
-	}
-
+	closer := func() { _ = c.Client.Unsubscribe(ctx, "kosu", q) }
 	return ch, closer, nil
-}
-
-// Unsubscribe unsubscribes given subscriber from query.
-func (c *Client) Unsubscribe(ctx context.Context, query string) error {
-	return c.Client.Unsubscribe(ctx, "kosu", query)
 }
 
 // QueryRoundInfo performs a ABCIQuery to "/roundinfo"

--- a/packages/go-kosu/rpc/cmd.go
+++ b/packages/go-kosu/rpc/cmd.go
@@ -51,11 +51,11 @@ func NewCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := abci.NewHTTPClient(url, key)
+			fn := func() (*abci.Client, error) { return abci.NewHTTPClient(url, key) }
+			srv, err := NewServer(fn)
 			if err != nil {
 				return err
 			}
-			srv := NewServer(client)
 
 			wg := sync.WaitGroup{}
 			if http {

--- a/packages/go-kosu/rpc/rpc_test.go
+++ b/packages/go-kosu/rpc/rpc_test.go
@@ -52,7 +52,10 @@ func TestRPC(t *testing.T) {
 			require.NoError(t, err)
 			defer appClient.Stop() // nolint:errcheck
 
-			rpcClient := rpc.DialInProc(NewServer(appClient))
+			srv, err := NewServer(app.NewClient)
+			require.NoError(t, err)
+
+			rpcClient := rpc.DialInProc(srv)
 			defer rpcClient.Close()
 
 			test.run(t, app, appClient, rpcClient)

--- a/packages/go-kosu/tests/order_test.go
+++ b/packages/go-kosu/tests/order_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
 	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci/types"
 	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/rpc"
 
@@ -78,9 +79,11 @@ func (suite *IntegrationTestSuite) TestOrders() {
 
 	suite.Run("RPCEvents", func() {
 		tx := NewOrderTx(suite.T())
-		rpcClient := rpc.DialInProc(
-			rpc.NewServer(suite.Client()),
-		)
+
+		srv, err := rpc.NewServer(func() (*abci.Client, error) { return suite.Client(), nil })
+		suite.Require().NoError(err)
+
+		rpcClient := rpc.DialInProc(srv)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/packages/go-kosu/tests/support.go
+++ b/packages/go-kosu/tests/support.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,10 @@ func StartServer(t *testing.T, db db.DB) (*abci.App, func()) {
 	for {
 		app, closer, err := startServer(t, db)
 		if err != nil {
+			if strings.Contains(err.Error(), "address already in use") {
+				t.Fatal(err)
+			}
+
 			closer()
 			time.Sleep(100 * time.Millisecond)
 			continue


### PR DESCRIPTION
Fix frozen subscriptions when two or more clients subscribe to events.
This happened because the current RPC client does not support more than one subscription.
The RPC Service now receives a client factory, so that it creates a new client on each subscription.