### PR TITLE
go-kosu: use MaxOrderBytes in CheckTx

### DIFF
--- a/packages/go-kosu/abci/app.go
+++ b/packages/go-kosu/abci/app.go
@@ -270,6 +270,11 @@ func (app *App) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 		}
 		return abci.ResponseCheckTx{}
 	case *types.Transaction_Order:
+		if max := app.store.ConsensusParams().MaxOrderBytes; max > 0 {
+			if uint32(len(req.Tx)) > max {
+				return abci.ResponseCheckTx{Code: 1, Log: fmt.Sprintf("Tx size exceeds %d", max)}
+			}
+		}
 		if err := app.checkOrderTx(tx.GetOrder()); err != nil {
 			return abci.ResponseCheckTx{Code: 1, Log: err.Error()}
 		}


### PR DESCRIPTION
Use MaxOrderBytes as a size limit to incoming Order TXs.
If the value is zero, the check is skipped.

This value SHOULD be specified in the genesis's `app_state` field