### PR TITLE
order-server: fix price quote error on /search endpoint

### DIFF
--- a/packages/order-server/src/db.ts
+++ b/packages/order-server/src/db.ts
@@ -64,7 +64,8 @@ export class DB {
 
         const qs = `SELECT * FROM orders WHERE\
             makerAssetData = '${makerAssetData}' AND \
-            takerAssetData = '${takerAssetData}' \
+            takerAssetData = '${takerAssetData}' AND \
+            expirationTimeSeconds > UNIX_TIMESTAMP(NOW()) \
             LIMIT ${page},${perPage}`;
         return this._query(qs);
     }

--- a/packages/order-server/src/routes/search.ts
+++ b/packages/order-server/src/routes/search.ts
@@ -10,7 +10,7 @@ export function searchClosure(db: DB): AsyncHandlerFunction {
         const { baseAsset, quoteAsset, side, page = 0, perPage = 10 } = req.query;
 
         const orders = await db.getOrdersForPair(baseAsset, quoteAsset, side, perPage, page);
-        const quotes = parseQuotesFromOrders(orders, side);
+        const quotes = parseQuotesFromOrders(baseAsset, orders);
         return res.status(200).send({ side, baseAsset, quoteAsset, page, perPage, quotes });
     };
 }


### PR DESCRIPTION
## Overview

The method used to render quote snapshots was detecting `bid` vs `ask` to determine the base an quote assets to generate the price, which was incorrect.

The price is based off weather the maker asset or the taker asset is the base asset, not what the side is.