### PR TITLE
Fix witness unsupported key logger

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+-   Fix witness unsupported key logger bug
 -   Fix Fix witness connection mngmt and error handling
 -   Remove confirmation_threshold from ConsensusParams
 -   Ethereum Snapshot block

--- a/packages/go-kosu/witness/witness.go
+++ b/packages/go-kosu/witness/witness.go
@@ -158,7 +158,7 @@ func (w *Witness) broadcastTxSync(tx interface{}, args []interface{}) {
 	}
 
 	if res.Code != 0 {
-		w.log.Error("BroadcastTxSync: WitnessTx", append(args, "code", res.Code))
+		w.log.Error("BroadcastTxSync: WitnessTx", append(args, "code", res.Code)...)
 	} else {
 		w.log.Info("BroadcastTxSync: WitnessTx", append(args, "hash", res.Hash[0:4])...)
 	}


### PR DESCRIPTION
We are using `append()` instead of `append()...` when logging the fields.
The logger expect something different that an array as a valid key, now we're expanding the array when passing it to the logging function