### PR TITLE
go-kosu: Add InitialPosters support

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+-   Add InitialPosters support
 -   Bump tendermint version from v0.32.3 to v0.32.4
 -   Sort ValidatorUpdates by address and returns updated set
 -   Fix witness unsupported key logger bug

--- a/packages/go-kosu/abci/app.go
+++ b/packages/go-kosu/abci/app.go
@@ -132,8 +132,11 @@ func (app *App) InitChain(req abci.RequestInitChain) abci.ResponseInitChain {
 		app.store.SetValidator(nodeID, &v)
 	}
 
-	for addr, p := range gen.InitialPosters {
-		app.store.SetPoster(addr, p)
+	for _, init := range gen.InitialPosters {
+		poster := types.Poster{
+			Balance: types.NewBigIntFromString(init.Balance, 10),
+		}
+		app.store.SetPoster(init.EthereumAddress, poster)
 	}
 
 	app.store.SetConsensusParams(gen.ConsensusParams)

--- a/packages/go-kosu/abci/app.go
+++ b/packages/go-kosu/abci/app.go
@@ -132,6 +132,10 @@ func (app *App) InitChain(req abci.RequestInitChain) abci.ResponseInitChain {
 		app.store.SetValidator(nodeID, &v)
 	}
 
+	for addr, p := range gen.InitialPosters {
+		app.store.SetPoster(addr, p)
+	}
+
 	app.store.SetConsensusParams(gen.ConsensusParams)
 	app.log.Info("Loaded Genesis State", "gen", gen)
 

--- a/packages/go-kosu/abci/app_test.go
+++ b/packages/go-kosu/abci/app_test.go
@@ -188,18 +188,16 @@ func TestGenesisStateCorrectness(t *testing.T) {
 					{"tendermint_address": "9339CD2572AB19E2A2E431EEF2E9FD2B1A91C472", "ethereum_address": "0xethereum", "initial_stake": "10000000000000000000"}
 				],
 				"snapshot_block": 999,
-				"initial_posters": {
-					"some_address": {
-						"balance": "1234", "limit": 10
-					}
-				}
+				"initial_posters": [
+					{"ethereum_address": "some_address", "balance": "1234"}
+				]
 			}`),
 			false,
 			func(res *abci.ResponseInitChain) {
 				p := app.store.Poster("some_address")
 				require.NotNil(t, p)
 				assert.EqualValues(t, 1234, p.Balance.BigInt().Int64())
-				assert.EqualValues(t, 10, p.Limit)
+				assert.EqualValues(t, 0, p.Limit, "Limit should not be set")
 			},
 		},
 	}
@@ -220,8 +218,7 @@ func TestGenesisStateCorrectness(t *testing.T) {
 		})
 	}
 
-	/*
-t.Run("Sorted", func(t *testing.T) {
+	t.Run("Sorted", func(t *testing.T) {
 		app.InitChain(abci.RequestInitChain{
 			Validators: abci.ValidatorUpdates{
 				abci.Ed25519ValidatorUpdate([]byte("z"), 2000),
@@ -230,13 +227,13 @@ t.Run("Sorted", func(t *testing.T) {
 				abci.Ed25519ValidatorUpdate([]byte("w"), 2003),
 			},
 			AppStateBytes: []byte(`{
-			"initial_validator_info": [
-				  {"tendermint_address": "50E721E49C013F00C62CF59F2163542A9D8DF024", "ethereum_address": "0xethereum1", "initial_stake": "2003000000000000000000"}
-				, {"tendermint_address": "2D711642B726B04401627CA9FBAC32F5C8530FB1", "ethereum_address": "0xethereum1", "initial_stake": "2002000000000000000000"}
-				, {"tendermint_address": "A1FCE4363854FF888CFF4B8E7875D600C2682390", "ethereum_address": "0xethereum1", "initial_stake": "2001000000000000000000"}
-				, {"tendermint_address": "594E519AE499312B29433B7DD8A97FF068DEFCBA", "ethereum_address": "0xethereum1", "initial_stake": "2000000000000000000000"}
-			],
-			"snapshot_block": 999
+				"initial_validator_info": [
+					  {"tendermint_address": "50E721E49C013F00C62CF59F2163542A9D8DF024", "ethereum_address": "0xethereum1", "initial_stake": "2003000000000000000000"}
+					, {"tendermint_address": "2D711642B726B04401627CA9FBAC32F5C8530FB1", "ethereum_address": "0xethereum1", "initial_stake": "2002000000000000000000"}
+					, {"tendermint_address": "A1FCE4363854FF888CFF4B8E7875D600C2682390", "ethereum_address": "0xethereum1", "initial_stake": "2001000000000000000000"}
+					, {"tendermint_address": "594E519AE499312B29433B7DD8A97FF068DEFCBA", "ethereum_address": "0xethereum1", "initial_stake": "2000000000000000000000"}
+				],
+				"snapshot_block": 999
 			}`),
 		})
 	})
@@ -251,13 +248,13 @@ t.Run("Sorted", func(t *testing.T) {
 		res := app.InitChain(abci.RequestInitChain{
 			Validators: updates,
 			AppStateBytes: []byte(`{
-			"initial_validator_info": [
-				  {"tendermint_address": "50E721E49C013F00C62CF59F2163542A9D8DF024", "ethereum_address": "0xethereum1", "initial_stake": "2003000000000000000000"}
-				, {"tendermint_address": "2D711642B726B04401627CA9FBAC32F5C8530FB1", "ethereum_address": "0xethereum1", "initial_stake": "2002000000000000000000"}
-				, {"tendermint_address": "A1FCE4363854FF888CFF4B8E7875D600C2682390", "ethereum_address": "0xethereum1", "initial_stake": "2001000000000000000000"}
-				, {"tendermint_address": "594E519AE499312B29433B7DD8A97FF068DEFCBA", "ethereum_address": "0xethereum1", "initial_stake": "2000000000000000000000"}
-			],
-			"snapshot_block": 999
+				"initial_validator_info": [
+					  {"tendermint_address": "50E721E49C013F00C62CF59F2163542A9D8DF024", "ethereum_address": "0xethereum1", "initial_stake": "2003000000000000000000"}
+					, {"tendermint_address": "2D711642B726B04401627CA9FBAC32F5C8530FB1", "ethereum_address": "0xethereum1", "initial_stake": "2002000000000000000000"}
+					, {"tendermint_address": "A1FCE4363854FF888CFF4B8E7875D600C2682390", "ethereum_address": "0xethereum1", "initial_stake": "2001000000000000000000"}
+					, {"tendermint_address": "594E519AE499312B29433B7DD8A97FF068DEFCBA", "ethereum_address": "0xethereum1", "initial_stake": "2000000000000000000000"}
+				],
+				"snapshot_block": 999
 			}`),
 		})
 
@@ -266,5 +263,4 @@ t.Run("Sorted", func(t *testing.T) {
 			assert.True(t, u.Power > 0)
 		}
 	})
-*/
 }

--- a/packages/go-kosu/abci/genesis.go
+++ b/packages/go-kosu/abci/genesis.go
@@ -27,8 +27,14 @@ func (s GenesisValidatorSet) Less(i, j int) bool {
 }
 func (s GenesisValidatorSet) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
-// GenesisPosterSet is a map of address to type.Poster used to define the initial poster set
-type GenesisPosterSet map[string]types.Poster
+// GenesisPoster is the data structure to define a poster in the app_state section of the genesis file.
+type GenesisPoster struct {
+	EthereumAddress string `json:"ethereum_address"`
+	Balance         string `json:"balance"`
+}
+
+// GenesisPosterSet is the initial set of posters
+type GenesisPosterSet []GenesisPoster
 
 // Genesis is the initial chain state
 type Genesis struct {

--- a/packages/go-kosu/abci/genesis.go
+++ b/packages/go-kosu/abci/genesis.go
@@ -27,12 +27,16 @@ func (s GenesisValidatorSet) Less(i, j int) bool {
 }
 func (s GenesisValidatorSet) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
+// GenesisPosterSet is a map of address to type.Poster used to define the initial poster set
+type GenesisPosterSet map[string]types.Poster
+
 // Genesis is the initial chain state
 type Genesis struct {
-	ConsensusParams      types.ConsensusParams `json:"consensus_params"`
-	InitialValidatorInfo GenesisValidatorSet   `json:"initial_validator_info"`
+	ConsensusParams types.ConsensusParams `json:"consensus_params"`
 	// SnapshotBlock indicates the first Ethereum block we will subscribe to
-	SnapshotBlock uint64 `json:"snapshot_block"`
+	SnapshotBlock        uint64              `json:"snapshot_block"`
+	InitialValidatorInfo GenesisValidatorSet `json:"initial_validator_info"`
+	InitialPosters       GenesisPosterSet    `json:"initial_posters"`
 }
 
 // NewGenesisFromRequest returnsa a new Genesis object given a RequestInitChain
@@ -84,6 +88,7 @@ var GenesisAppState = &Genesis{
 		PeriodLimit:         100000,
 		BlocksBeforePruning: 10,
 	},
-	InitialValidatorInfo: nil,
 	SnapshotBlock:        0,
+	InitialValidatorInfo: nil,
+	InitialPosters:       nil,
 }

--- a/packages/go-kosu/abci/types/types.go
+++ b/packages/go-kosu/abci/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math/big"
@@ -23,6 +24,18 @@ func (b *BigInt) MarshalText() ([]byte, error) {
 	n := big.NewInt(0).SetBytes(b.Value)
 	str := fmt.Sprintf("value: %s", n.String())
 	return []byte(str), nil
+}
+
+// UnmarshalJSON is defined to parse BigInt from JSON.
+// The BigInt value MUST be encoded as string.
+func (b *BigInt) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	b.Value = NewBigIntFromString(str, 10).Bytes()
+	return nil
 }
 
 // Zero returns true if the value is 0


### PR DESCRIPTION
InitialPosters are defined like this:
```json
{
	"initial_validator_info": [],
	"snapshot_block": 999,
	"initial_posters": {
		"some_address": {
			"balance": "1234", "limit": 10
	}
}
```

As the balance is a BigNum is represented as a string in the JSON.