### PR TITLE
Feature/go kosu/lite client

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+-   Add /store prefix to Query Path
 -   Add InitialPosters support
 -   Bump tendermint version from v0.32.3 to v0.32.4
 -   Sort ValidatorUpdates by address and returns updated set

--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+-   Add kosulite proxy
 -   [bug] Fix panic on kosu-cli
 -   Add /store prefix to Query Path
 -   Add InitialPosters support

--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+-   [bug] Fix panic on kosu-cli
 -   Add /store prefix to Query Path
 -   Add InitialPosters support
 -   Bump tendermint version from v0.32.3 to v0.32.4

--- a/packages/go-kosu/abci/app.go
+++ b/packages/go-kosu/abci/app.go
@@ -77,11 +77,7 @@ func (app *App) NewClient() (*Client, error) {
 // Query queries the application state using the store.Query method
 func (app *App) Query(req abci.RequestQuery) abci.ResponseQuery {
 	path := req.Path
-
-	// Remove the initial "/" if present
-	if strings.HasPrefix(path, "/") {
-		path = path[1:]
-	}
+	path = strings.TrimPrefix(path, "/")
 
 	// Get the first segment (resource) of the path
 	paths := strings.SplitN(path, "/", 2)

--- a/packages/go-kosu/abci/client.go
+++ b/packages/go-kosu/abci/client.go
@@ -108,7 +108,7 @@ func (c *Client) Subscribe(ctx context.Context, q string) (<-chan rpctypes.Resul
 // QueryRoundInfo performs a ABCIQuery to "/roundinfo"
 func (c *Client) QueryRoundInfo() (*types.RoundInfo, error) {
 	var pb types.RoundInfo
-	if err := c.Query("/chain/key", []byte("roundinfo"), &pb); err != nil {
+	if err := c.Query("/store/chain/key", []byte("roundinfo"), &pb); err != nil {
 		return nil, err
 	}
 
@@ -118,7 +118,7 @@ func (c *Client) QueryRoundInfo() (*types.RoundInfo, error) {
 // QueryConsensusParams performs a ABCI Query to "/consensusparams"
 func (c *Client) QueryConsensusParams() (*types.ConsensusParams, error) {
 	var pb types.ConsensusParams
-	if err := c.Query("/chain/key", []byte("consensusparams"), &pb); err != nil {
+	if err := c.Query("/store/chain/key", []byte("consensusparams"), &pb); err != nil {
 		if err == ErrNotFound {
 			return &types.ConsensusParams{}, nil
 		}
@@ -131,7 +131,7 @@ func (c *Client) QueryConsensusParams() (*types.ConsensusParams, error) {
 // QueryLastEvent performs a ABCI Query to "/lastevent".
 // `lastevent` keeps track of the last block height recorded from the Ethereum chain
 func (c *Client) QueryLastEvent() (uint64, error) {
-	out, err := c.ABCIQuery("/chain/key", []byte("lastevent"))
+	out, err := c.ABCIQuery("/store/chain/key", []byte("lastevent"))
 	if err != nil {
 		return 0, err
 	}
@@ -152,7 +152,7 @@ func (c *Client) QueryLastEvent() (uint64, error) {
 // QueryPoster performs a ABCI Query to "/posters/<addr>"
 func (c *Client) QueryPoster(addr string) (*types.Poster, error) {
 	var pb types.Poster
-	if err := c.Query("/poster/key", []byte(addr), &pb); err != nil {
+	if err := c.Query("/store/poster/key", []byte(addr), &pb); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +162,7 @@ func (c *Client) QueryPoster(addr string) (*types.Poster, error) {
 // QueryValidator performs a ABCI Query to "/validator/<addr>"
 func (c *Client) QueryValidator(addr string) (*types.Validator, error) {
 	var pb types.Validator
-	if err := c.Query("/validator/key", []byte(addr), &pb); err != nil {
+	if err := c.Query("/store/validator/key", []byte(addr), &pb); err != nil {
 		return nil, err
 	}
 
@@ -172,7 +172,7 @@ func (c *Client) QueryValidator(addr string) (*types.Validator, error) {
 // QueryTotalOrders performs a ABCI Query to "/chain/totalorders"
 func (c *Client) QueryTotalOrders() (uint64, error) {
 	var num uint64
-	if err := c.Query("/chain/key", []byte("totalorders"), &num); err != nil {
+	if err := c.Query("/store/chain/key", []byte("totalorders"), &num); err != nil {
 		return 0, err
 	}
 

--- a/packages/go-kosu/abci/lite.go
+++ b/packages/go-kosu/abci/lite.go
@@ -1,0 +1,47 @@
+package abci
+
+import (
+	"github.com/cosmos/cosmos-sdk/store/rootmulti"
+	"github.com/tendermint/iavl"
+	"github.com/tendermint/tendermint/lite"
+	"github.com/tendermint/tendermint/lite/client"
+	"github.com/tendermint/tendermint/lite/proxy"
+	rpcclient "github.com/tendermint/tendermint/rpc/client"
+	dbm "github.com/tendermint/tm-db"
+)
+
+// NewLite returns a RPC Client that uses the Lite client protocol.
+// All the responses are verified with merkle proofs.
+func NewLite(id string, endpoint string) (*proxy.Wrapper, error) {
+	memProvider := lite.NewDBProvider("trusted.mem", dbm.NewMemDB()).SetLimit(10)
+	lvlProvider := lite.NewDBProvider("trusted.lvl", dbm.NewDB("trust-base", dbm.GoLevelDBBackend, "."))
+	trust := lite.NewMultiProvider(
+		memProvider,
+		lvlProvider,
+	)
+
+	node := rpcclient.NewHTTP(endpoint, "/websocket")
+	source := client.NewProvider(id, node)
+
+	cert := lite.NewDynamicVerifier(id, trust, source)
+
+	_, err := trust.LatestFullCommit(id, 1, 1<<63-1)
+	if err != nil {
+		fc, err := source.LatestFullCommit(id, 1, 1)
+		if err != nil {
+			return nil, err
+
+		}
+		err = trust.SaveFullCommit(fc)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sc := proxy.SecureClient(node, cert)
+	sc.RegisterOpDecoder(iavl.ProofOpIAVLValue, iavl.IAVLValueOpDecoder)
+	sc.RegisterOpDecoder(iavl.ProofOpIAVLAbsence, iavl.IAVLAbsenceOpDecoder)
+	sc.RegisterOpDecoder(rootmulti.ProofOpMultiStore, rootmulti.MultiStoreProofOpDecoder)
+
+	return &sc, nil
+}

--- a/packages/go-kosu/cmd/kosu-cli/main.go
+++ b/packages/go-kosu/cmd/kosu-cli/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 func main() {
-	var client *abci.Client
+	var client abci.Client
 
 	rootCmd := &cobra.Command{
 		Use:   "kosu-cli",
@@ -46,11 +46,16 @@ func main() {
 		addr := cmd.Flag("abci").Value.String()
 
 		// update the client
-		client, err = abci.NewHTTPClient(addr, key)
+		c, err := abci.NewHTTPClient(addr, key)
+		if err != nil {
+			return err
+		}
+
+		client = *c
 		return err
 	}
 
-	abci := cli.New(client)
+	abci := cli.New(&client)
 
 	tx := &cobra.Command{
 		Use:   "tx",

--- a/packages/go-kosu/cmd/kosulite/main.go
+++ b/packages/go-kosu/cmd/kosulite/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/abci"
+	tmlog "github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/lite/proxy"
+)
+
+func main() {
+	flag.Parse()
+	chainID := flag.Arg(0)
+	if chainID == "" {
+		fmt.Printf("Usage: kosulite <chain-id>")
+	}
+
+	fmt.Printf("starting...\n")
+	sc, err := abci.NewLite(chainID, "localhost:26657")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := proxy.StartProxy(*sc, "tcp://localhost:9999", tmlog.NewTMLogger(os.Stdout), 99); err != nil {
+		log.Printf("err = %+v\n", err)
+	}
+
+}

--- a/packages/go-kosu/go.mod
+++ b/packages/go-kosu/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0
+	github.com/tendermint/iavl v0.12.4
 	github.com/tendermint/tendermint v0.32.4
 	github.com/tendermint/tm-db v0.2.0
 	github.com/tidwall/gjson v1.3.0

--- a/packages/go-kosu/rpc/service.go
+++ b/packages/go-kosu/rpc/service.go
@@ -847,7 +847,7 @@ _Returns:_
 func (s *Service) NumberPosters() (uint64, error) {
 	var num uint64
 
-	if err := s.abci.Query("/poster/number", nil, &num); err != nil {
+	if err := s.abci.Query("/store/poster/number", nil, &num); err != nil {
 		return 0, newQueryError(err)
 	}
 
@@ -871,7 +871,7 @@ _Returns:_
 func (s *Service) RemainingLimit() (uint64, error) {
 	var num uint64
 
-	if err := s.abci.Query("/poster/remaininglimit", nil, &num); err != nil {
+	if err := s.abci.Query("/store/poster/remaininglimit", nil, &num); err != nil {
 		return 0, newQueryError(err)
 	}
 

--- a/packages/go-kosu/tests/witness_test.go
+++ b/packages/go-kosu/tests/witness_test.go
@@ -56,7 +56,7 @@ func (suite *IntegrationTestSuite) TestWitness() {
 		tx1 := newTx()
 		suite.BroadcastTxCommit(tx1)
 
-		res, err := suite.Client().ABCIQuery("/witness/key", tx1.Hash())
+		res, err := suite.Client().ABCIQuery("/store/witness/key", tx1.Hash())
 		suite.Require().NoError(err)
 		suite.Require().NotNil(res.Response.Value)
 		suite.Require().NotEmpty(res.Response.Value)
@@ -65,7 +65,7 @@ func (suite *IntegrationTestSuite) TestWitness() {
 		tx2.Block = abci.GenesisAppState.ConsensusParams.BlocksBeforePruning + tx1.Block
 		suite.BroadcastTxCommit(tx2)
 
-		res, err = suite.Client().ABCIQuery("/witness/key", tx1.Hash())
+		res, err = suite.Client().ABCIQuery("/store/witness/key", tx1.Hash())
 		suite.Require().NoError(err)
 
 		suite.Empty(res.Response.Value)


### PR DESCRIPTION
## Overview
This implements a basic Lite Client. The LiteClient is implemented as a RPC Client (`./abci/lite.go`) and also as a Proxy sub-command (`./cmd/kosulite/`) so that `./kosu-cli` can use the lite client proxy as an endpoint.

This PR also includes fixes a `./kosu-cli` bug and it restructures the Query Path adding the `./store/` prefix, this change was required to make the lite client works.