### PR TITLE
genesis-cli: set snapshot power to 1

### DIFF
--- a/packages/kosu-genesis-cli/src/functions.ts
+++ b/packages/kosu-genesis-cli/src/functions.ts
@@ -197,7 +197,9 @@ export async function snapshotPostersAtBlock(kosu: Kosu, snapshotBlock: number):
                 }
 
                 if (!postersMap[address]) {
-                    (postersMap[address] as Partial<SnapshotPoster>) = { address };
+                    (postersMap[address] as Partial<SnapshotPoster>) = {
+                        ethereum_address: address,
+                    };
                 }
                 postersMap[address].balance = balance;
                 break;
@@ -246,6 +248,7 @@ export function getTendermintValidators(validators: SnapshotValidator[]): Genesi
                 value: validator.publicKey.toString("base64"),
             },
             name: parseMonikerFromDetails(validator.details),
+            power: "1",
         });
     }
     return genesisValidators;

--- a/packages/kosu-genesis-cli/src/types.d.ts
+++ b/packages/kosu-genesis-cli/src/types.d.ts
@@ -33,7 +33,7 @@ export interface GenesisValidator {
         type: string;
         value: string;
     };
-    power?: string;
+    power: string;
     name: string;
 }
 
@@ -51,6 +51,6 @@ export interface SnapshotValidator extends SnapshotListing {
 }
 
 export interface SnapshotPoster {
-    address: string;
+    ethereum_address: string;
     balance: string;
 }

--- a/packages/kosu-genesis-cli/test/snapshot_test.ts
+++ b/packages/kosu-genesis-cli/test/snapshot_test.ts
@@ -12,7 +12,7 @@ import Web3ProviderEngine from "web3-provider-engine";
 
 import { snapshotPostersAtBlock, snapshotValidatorsAtBlock } from "..";
 
-describe("Snapshot tests with contract system (integration tests)", function(): void {
+describe("Snapshot tests with contract system (integration tests)", function (): void {
     let kosu: Kosu;
     let assert: Chai.AssertStatic;
     let provider: Web3ProviderEngine;
@@ -158,7 +158,7 @@ describe("Snapshot tests with contract system (integration tests)", function(): 
         const currentBlock = await web3.eth.getBlockNumber();
         const expectedSnapshot = [
             {
-                address: accounts[0].toLowerCase(),
+                ethereum_address: accounts[0].toLowerCase(),
                 balance: new BigNumber("1e18").toString(),
             },
         ];

--- a/packages/kosu-genesis-cli/test/snapshot_test.ts
+++ b/packages/kosu-genesis-cli/test/snapshot_test.ts
@@ -12,7 +12,7 @@ import Web3ProviderEngine from "web3-provider-engine";
 
 import { snapshotPostersAtBlock, snapshotValidatorsAtBlock } from "..";
 
-describe("Snapshot tests with contract system (integration tests)", function (): void {
+describe("Snapshot tests with contract system (integration tests)", function(): void {
     let kosu: Kosu;
     let assert: Chai.AssertStatic;
     let provider: Web3ProviderEngine;

--- a/packages/kosu-genesis-cli/test/unit_test.ts
+++ b/packages/kosu-genesis-cli/test/unit_test.ts
@@ -180,7 +180,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
             ],
             initial_poster_info: [
                 {
-                    address: testPosterAddress,
+                    ethereum_address: testPosterAddress,
                     balance: testPosterBalance,
                 },
             ],

--- a/packages/kosu-genesis-cli/test/unit_test.ts
+++ b/packages/kosu-genesis-cli/test/unit_test.ts
@@ -11,8 +11,8 @@ import {
     publicKeyToAddress,
 } from "..";
 
-describe("Snapshot function blockchain-less tests (unit tests)", function(): void {
-    it("#dateFromTimestamp", function(): void {
+describe("Snapshot function blockchain-less tests (unit tests)", function (): void {
+    it("#dateFromTimestamp", function (): void {
         const date = new Date();
         const ts = date.getTime() / 1000;
         const generatedDate = dateFromTimestamp(ts);
@@ -22,7 +22,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(actualTime, expectedTime, "local time strings should match");
     });
 
-    it("#parseMonikerFromDetails", function(): void {
+    it("#parseMonikerFromDetails", function (): void {
         const expectedMoniker = "alice";
         const stringWithMoniker = `website=https://example.com,moniker=${expectedMoniker}`;
         const stringWithoutMoniker = "an ordinary string with no keys";
@@ -39,7 +39,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         );
     });
 
-    it("#hexKeyToBase64", function(): void {
+    it("#hexKeyToBase64", function (): void {
         const knownKey = Buffer.allocUnsafe(32);
         const knownHexKey = `0x${knownKey.toString("hex").toUpperCase()}`;
         const expectedBase64Key = knownKey.toString("base64");
@@ -48,7 +48,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(actualBase64Key, expectedBase64Key, "base64 keys should match test case");
     });
 
-    it("#publicKeyToAddress", function(): void {
+    it("#publicKeyToAddress", function (): void {
         const knownHexKey = "0x2D03EA48ADDC6B56DC1D456ED8778C8152EDC74F58572306BB3353DDEFFAE2E5";
         const expectedAddress = "6E759A69DAF556E8C492D6AA9E263A6168F688B7";
 
@@ -58,7 +58,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(generatedAddress, expectedAddress, "generated address should match test case");
     });
 
-    it("#getInitialValidatorInfo", function(): void {
+    it("#getInitialValidatorInfo", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -95,7 +95,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(initial_stake, testInitialStake, "initial stakes should match snapshot");
     });
 
-    it("#getTendermintValidators", function(): void {
+    it("#getTendermintValidators", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -137,7 +137,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(name, testDetails, "validator name should match snapshot details");
     });
 
-    it("#getAppState", function(): void {
+    it("#getAppState", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -165,7 +165,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         ];
         const testPosterSnapshots = [
             {
-                address: testPosterAddress,
+                ethereum_address: testPosterAddress,
                 balance: testPosterBalance,
             },
         ];

--- a/packages/kosu-genesis-cli/test/unit_test.ts
+++ b/packages/kosu-genesis-cli/test/unit_test.ts
@@ -11,8 +11,8 @@ import {
     publicKeyToAddress,
 } from "..";
 
-describe("Snapshot function blockchain-less tests (unit tests)", function(): void {
-    it("#dateFromTimestamp", function(): void {
+describe("Snapshot function blockchain-less tests (unit tests)", function (): void {
+    it("#dateFromTimestamp", function (): void {
         const date = new Date();
         const ts = date.getTime() / 1000;
         const generatedDate = dateFromTimestamp(ts);
@@ -22,7 +22,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(actualTime, expectedTime, "local time strings should match");
     });
 
-    it("#parseMonikerFromDetails", function(): void {
+    it("#parseMonikerFromDetails", function (): void {
         const expectedMoniker = "alice";
         const stringWithMoniker = `website=https://example.com,moniker=${expectedMoniker}`;
         const stringWithoutMoniker = "an ordinary string with no keys";
@@ -39,7 +39,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         );
     });
 
-    it("#hexKeyToBase64", function(): void {
+    it("#hexKeyToBase64", function (): void {
         const knownKey = Buffer.allocUnsafe(32);
         const knownHexKey = `0x${knownKey.toString("hex").toUpperCase()}`;
         const expectedBase64Key = knownKey.toString("base64");
@@ -48,7 +48,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(actualBase64Key, expectedBase64Key, "base64 keys should match test case");
     });
 
-    it("#publicKeyToAddress", function(): void {
+    it("#publicKeyToAddress", function (): void {
         const knownHexKey = "0x2D03EA48ADDC6B56DC1D456ED8778C8152EDC74F58572306BB3353DDEFFAE2E5";
         const expectedAddress = "6E759A69DAF556E8C492D6AA9E263A6168F688B7";
 
@@ -58,7 +58,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(generatedAddress, expectedAddress, "generated address should match test case");
     });
 
-    it("#getInitialValidatorInfo", function(): void {
+    it("#getInitialValidatorInfo", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -95,7 +95,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(initial_stake, testInitialStake, "initial stakes should match snapshot");
     });
 
-    it("#getTendermintValidators", function(): void {
+    it("#getTendermintValidators", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -119,6 +119,9 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
                     value: testPubKey.toString("base64"),
                 },
                 name: testDetails,
+
+                // snapshot validators must all set power to 1
+                power: "1",
             },
         ];
 
@@ -134,7 +137,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function(): voi
         assert.strictEqual(name, testDetails, "validator name should match snapshot details");
     });
 
-    it("#getAppState", function(): void {
+    it("#getAppState", function (): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);

--- a/packages/kosu-genesis-cli/test/unit_test.ts
+++ b/packages/kosu-genesis-cli/test/unit_test.ts
@@ -11,8 +11,8 @@ import {
     publicKeyToAddress,
 } from "..";
 
-describe("Snapshot function blockchain-less tests (unit tests)", function (): void {
-    it("#dateFromTimestamp", function (): void {
+describe("Snapshot function blockchain-less tests (unit tests)", function(): void {
+    it("#dateFromTimestamp", function(): void {
         const date = new Date();
         const ts = date.getTime() / 1000;
         const generatedDate = dateFromTimestamp(ts);
@@ -22,7 +22,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         assert.strictEqual(actualTime, expectedTime, "local time strings should match");
     });
 
-    it("#parseMonikerFromDetails", function (): void {
+    it("#parseMonikerFromDetails", function(): void {
         const expectedMoniker = "alice";
         const stringWithMoniker = `website=https://example.com,moniker=${expectedMoniker}`;
         const stringWithoutMoniker = "an ordinary string with no keys";
@@ -39,7 +39,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         );
     });
 
-    it("#hexKeyToBase64", function (): void {
+    it("#hexKeyToBase64", function(): void {
         const knownKey = Buffer.allocUnsafe(32);
         const knownHexKey = `0x${knownKey.toString("hex").toUpperCase()}`;
         const expectedBase64Key = knownKey.toString("base64");
@@ -48,7 +48,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         assert.strictEqual(actualBase64Key, expectedBase64Key, "base64 keys should match test case");
     });
 
-    it("#publicKeyToAddress", function (): void {
+    it("#publicKeyToAddress", function(): void {
         const knownHexKey = "0x2D03EA48ADDC6B56DC1D456ED8778C8152EDC74F58572306BB3353DDEFFAE2E5";
         const expectedAddress = "6E759A69DAF556E8C492D6AA9E263A6168F688B7";
 
@@ -58,7 +58,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         assert.strictEqual(generatedAddress, expectedAddress, "generated address should match test case");
     });
 
-    it("#getInitialValidatorInfo", function (): void {
+    it("#getInitialValidatorInfo", function(): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -95,7 +95,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         assert.strictEqual(initial_stake, testInitialStake, "initial stakes should match snapshot");
     });
 
-    it("#getTendermintValidators", function (): void {
+    it("#getTendermintValidators", function(): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);
@@ -137,7 +137,7 @@ describe("Snapshot function blockchain-less tests (unit tests)", function (): vo
         assert.strictEqual(name, testDetails, "validator name should match snapshot details");
     });
 
-    it("#getAppState", function (): void {
+    it("#getAppState", function(): void {
         const testPubKey = Buffer.allocUnsafe(32);
         const testEthAddress = `0x${Buffer.allocUnsafe(20).toString("hex")}`;
         const testTendermintAddress = publicKeyToAddress(testPubKey);


### PR DESCRIPTION
## Overview

Tendermint requires initial power to be set, even though it gets overidden by go-kosu. 

## Description

- The convention is that snapshot validators all set `power` as `"1"`
- Changed `SnapshotPoster` key `address` to `ethereum_address` (as expected by client)