### PR TITLE
go-kosu: add remote signer support

### DIFF
--- a/packages/go-kosu/abci/node.go
+++ b/packages/go-kosu/abci/node.go
@@ -4,51 +4,47 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"github.com/tendermint/tendermint/cmd/tendermint/commands"
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto/ed25519"
-	tmflags "github.com/tendermint/tendermint/libs/cli/flags"
 	log "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
-	pv "github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
+	"github.com/tendermint/tendermint/types"
 )
 
+// NodeOptions defines a set of options to create a node
+type NodeOptions struct {
+	PrivValidator types.PrivValidator
+}
+
 // CreateNode creates an embedded tendermint node for standalone mode
-func (app *App) CreateNode() (*node.Node, error) {
+func (app *App) CreateNode(opts NodeOptions) (*node.Node, error) {
+	// if the PrivValidator is not defined we fallback to the one defined in the config
+	if opts.PrivValidator == nil {
+		opts.PrivValidator = privval.LoadOrGenFilePV(
+			app.Config.PrivValidatorKeyFile(),
+			app.Config.PrivValidatorStateFile(),
+		)
+	}
+
 	// Assumes priv validator has been generated.  See setup()
 	nodeKey, err := p2p.LoadOrGenNodeKey(app.Config.NodeKeyFile())
 	if err != nil {
 		return nil, err
 	}
 
-	var w log.Logger
-	switch app.Config.LogFormat {
-	case "json":
-		w = log.NewTMJSONLogger(os.Stdout)
-	case "", "plain":
-		w = log.NewTMLogger(os.Stdout)
-	case "none":
-		w = log.NewNopLogger()
-	default:
-		w = log.NewNopLogger()
-	}
-
-	logger, err := tmflags.ParseLogLevel(app.Config.LogLevel, w, "error")
+	logger, err := NewLogger(app.Config)
 	if err != nil {
 		return nil, err
 	}
 
 	node, err := node.NewNode(
 		app.Config,
-		pv.LoadOrGenFilePV(
-			app.Config.PrivValidatorKeyFile(),
-			app.Config.PrivValidatorStateFile(),
-		),
+		opts.PrivValidator,
 		nodeKey,
 		proxy.NewLocalClientCreator(app),
 		node.DefaultGenesisDocProviderFunc(app.Config),

--- a/packages/go-kosu/abci/server.go
+++ b/packages/go-kosu/abci/server.go
@@ -16,7 +16,12 @@ type Server struct {
 
 // StartInProcessServer starts an InProcess ABCI app and server
 func StartInProcessServer(app *App) (*Server, error) {
-	tm, err := app.CreateNode()
+	return StartInProcessServerWithNodeOptions(app, NodeOptions{})
+}
+
+// StartInProcessServerWithNodeOptions starts an InProcess ABCI app and server using custom options
+func StartInProcessServerWithNodeOptions(app *App, opts NodeOptions) (*Server, error) {
+	tm, err := app.CreateNode(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-kosu/service/cmd.go
+++ b/packages/go-kosu/service/cmd.go
@@ -9,12 +9,13 @@ import (
 
 // CommandConfig are the config parameter for the command
 type CommandConfig struct {
-	Home         string
-	Web3         string
-	LiteFullnode string
-	LAddr        string
-	RPC          bool
-	Lite         bool
+	Home                 string
+	Web3                 string
+	LiteFullnode         string
+	LAddr                string
+	RPC                  bool
+	Lite                 bool
+	RemoteSignerListener string
 }
 
 // RegisterCommand register flags and logic into a cobra command to start a node
@@ -27,6 +28,8 @@ func RegisterCommand(cmd *cobra.Command, homeFlag string) {
 	cmd.Flags().BoolVarP(&cfg.Lite, "lite", "", false, "Start the node as a Lite client")
 	cmd.Flags().StringVarP(&cfg.LiteFullnode, "lite-fullnode", "", "http://localhost:26657",
 		"Fullnode's endpoint (required when running with --lite)")
+	cmd.Flags().StringVarP(&cfg.RemoteSignerListener, "remote-signer-listener", "", "",
+		"If set, kosud will use a remote signer (pointing to this address) to sign blocks")
 	rpcArgs := rpc.RegisterServerArgs("rpc", cmd)
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if cfg.RPC {
@@ -42,9 +45,10 @@ func RegisterCommand(cmd *cobra.Command, homeFlag string) {
 		}
 
 		srv := Service{
-			HomeDir: home,
-			WEB3:    cfg.Web3,
-			LAddr:   cfg.LAddr,
+			HomeDir:              home,
+			WEB3:                 cfg.Web3,
+			LAddr:                cfg.LAddr,
+			RemoteSignerListener: cfg.RemoteSignerListener,
 		}
 
 		if cfg.Lite {


### PR DESCRIPTION
## Overview
Remote signer support added with the new `--remote-signer-listener`

## Description
If set, what `--remote-signer-listener` does is to open a listening connection bound to the argument. From that point kosud will sign blocks using a remote signer, the remote signer connects to us, and not the other way around.

## Testing instructions
In order to test this, I installed and configure [tmkms](https://github.com/tendermint/kms) with softkey support (you can enable ledger and yubikey support too); softkey will use the filesystem keys.

The whole process is described [here](https://github.com/tendermint/tendermint/blob/master/docs/tools/remote-signer-validation.md), the document is a bit outdated because tmkms has been updated. You'll need to prefix `softsign` to the `keygen` subcommand and use the `config.toml` below. 

```bash
cargo install tmkms --features softsign
```

Using this config file:
```toml
[[validator]]
addr = "tcp://127.0.0.1:61219"         # This is where we will find tm-signer-harness.
chain_id = "kosu-chain-Sz2uIW"         # The Tendermint chain ID for which KMS will be signing (found in ~/.tendermint/config/genesis.json).
reconnect = true                       # true is the default
secret_key = "./secret_connection.key" # Where to find our secret connection key.

[[chain]]
id = "kosu-chain-Sz2uIW"
key_format = { type = "hex"} #, account_key_prefix = "cosmospub", consensus_key_prefix = "cosmosvalconspub"  }
# state_file = "/path/to/cosmoshub_priv_validator_state.json"
# state_hook = { cmd = ["/path/to/block/height_script", "--example-arg", "cosmoshub"]  }

[[providers.softsign]]
chain_ids = ["kosu-chain-Sz2uIW"]              # The Tendermint chain ID for which KMS will be signing (same as validator.chain_id above).
path = "./signing.key" 
```

* `addr` needs to match with `--remote-signer-listener`
* `chain_id` needs to match the node's chain id
* `secret_key` is generated like this: `tmkms softsign keygen secret_connection.key`
* `path = "./signing.key"` is the kosud/tendermint signing key, and it's generated with the internal tendermint tool tm-signer-harness.

Once the keys are generated you should start `tmkms`
```bash
tmkms start -c tmkms.toml
```

And kosud with the remote signer enabled
```
kosud start --remote-signer-listener tcp://127.0.0.1:61219
```