### PR TITLE
kosu-genesis-cli: add orders limit consensus parameter

### DIFF
--- a/packages/kosu-genesis-cli/src/cli/cli.ts
+++ b/packages/kosu-genesis-cli/src/cli/cli.ts
@@ -26,4 +26,5 @@ cli.version("0.0.0")
     .option("-l, --period-limit <number>", "Maximum number of order messages to accept per rebalance period", "100000")
     .option("-L, --period-length <number>", "The length of each rebalance period (in Ethereum blocks)", "5")
     .option("-m, --max-order-bytes <number>", "The maximum size of a single order transaction", "4096")
-    .option("-B, --blocks-before-pruning <number>", "Maximum age of attestations before pruning", "50");
+    .option("-B, --blocks-before-pruning <number>", "Maximum age of attestations before pruning", "50")
+    .option("-o, --orders-limit <number>", "The maximum number of orders to keep in state at time", "100");

--- a/packages/kosu-genesis-cli/src/cli/utils.ts
+++ b/packages/kosu-genesis-cli/src/cli/utils.ts
@@ -4,13 +4,14 @@ import { Command } from "commander";
 import { ConsensusParams } from "../types";
 
 export function loadConsensusParameters(program: Command): ConsensusParams {
-    const { finalityThreshold, periodLimit, periodLength, maxOrderBytes, blocksBeforePruning } = program;
+    const { finalityThreshold, periodLimit, periodLength, maxOrderBytes, blocksBeforePruning, ordersLimit } = program;
     return {
         finality_threshold: parseInt(finalityThreshold, 10),
         period_limit: parseInt(periodLimit, 10),
         period_length: parseInt(periodLength, 10),
         max_order_bytes: parseInt(maxOrderBytes, 10),
         blocks_before_pruning: parseInt(blocksBeforePruning, 10),
+        orders_limit: parseInt(ordersLimit, 10),
     };
 }
 

--- a/packages/kosu-genesis-cli/src/types.d.ts
+++ b/packages/kosu-genesis-cli/src/types.d.ts
@@ -12,6 +12,7 @@ export interface ConsensusParams {
     period_length: number;
     max_order_bytes: number;
     blocks_before_pruning: number;
+    orders_limit: number;
 }
 
 export interface AppState {


### PR DESCRIPTION
## Overview

Adding orders buffer size consensus parameter to genesis cli to keep in line with `go-kosu` (see #321).