### PR TITLE
fix drone release step (re-add git checkout)

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -86,6 +86,7 @@ local KosuGeth(name) = Image(name, "kosu-test-geth:latest") {
                 "yarn build",
                 "yarn prettier",
                 "npm-cli-login",
+                "git checkout .",
                 "yarn lerna publish from-package --yes" 
             ],
             "when": {

--- a/.drone.yml
+++ b/.drone.yml
@@ -138,6 +138,7 @@ steps:
   - yarn build
   - yarn prettier
   - npm-cli-login
+  - git checkout .
   - yarn lerna publish from-package --yes
   environment:
     NPM_EMAIL:


### PR DESCRIPTION
## Overview

We must `git checkout .` to remove the auto-generated `bindata.go` file after `yarn build`.