### PR TITLE
cloudbuild: update path name for copy step

### DIFF
--- a/cloudbuild/main.yaml
+++ b/cloudbuild/main.yaml
@@ -82,8 +82,8 @@ steps:
     "-m", 
     "rsync", 
     "-r", "-c", "-d", 
-    "./packages/kosu.js/docs",
-    "./packages/kosu-docs/docs/kosu.js"
+    "./packages/kosu-contract-helpers/docs",
+    "./packages/kosu-docs/docs/kosu-contract-helpers"
   ]
 
 - name: "gcr.io/cloud-builders/gsutil"


### PR DESCRIPTION
## Overview

An update to the docs deploy steps got left out of #335 (due to `kosu.js` => `kosu-contract-helpers` rename).