### PR TITLE
go-kosu: Fix wrong RPC remote address in lite mode

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+-   Fix wrong RPC remote address in lite mode
+
 ## v0.4.0
 
 -   Add LatestOrders RPC endpoint


### PR DESCRIPTION
The `--laddr` where used as the rpc target, that makes sense when running in fullnode mode, so that the RPC API will connect to it. But in lite mode, we should connect to the fullnode, before this PR we were using `--laddr` for both modes.

This PR updates that behavior.

Closes #330 