### PR TITLE
dev-images: fixing broken go-ethereum installs

### DIFF
--- a/packages/dev-images/README.md
+++ b/packages/dev-images/README.md
@@ -1,4 +1,4 @@
-# `@kosu/dev-images`
+# Kosu development images
 
 Development and CI docker images and supporting scripts for the Kosu project.
 

--- a/packages/dev-images/ci/go-kosu.Dockerfile
+++ b/packages/dev-images/ci/go-kosu.Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /home/go-kosu
 
 ENV GOCACHE=/home/.go-build
 ENV GO111MODULE=on
+ENV GOROOT=/usr/local/go
+ENV GOPATH=/home/go
 
 ENV GOLINTCI_RELEASE=1.18.0
 

--- a/packages/dev-images/ci/go-kosu.Dockerfile
+++ b/packages/dev-images/ci/go-kosu.Dockerfile
@@ -1,9 +1,9 @@
 # the image drone-ci should use to build go-kosu
 FROM golang:1.13-stretch
 
-WORKDIR $HOME/go-kosu
+WORKDIR /home/go-kosu
 
-ENV GOCACHE=$HOME/.go-build
+ENV GOCACHE=/home/.go-build
 ENV GO111MODULE=on
 
 ENV GOLINTCI_RELEASE=1.18.0
@@ -12,9 +12,9 @@ ENV GOLINTCI_RELEASE=1.18.0
 RUN apt-get update
 RUN apt-get install -y unzip build-essential jq
 
-RUN git clone https://github.com/ethereum/go-ethereum
-RUN cd go-ethereum && make devtools
-RUN rm -rf go-ethereum
+RUN git clone -b release/1.8 https://github.com/ethereum/go-ethereum /home/go/src/github.com/ethereum/go-ethereum
+RUN cd /home/go/src/github.com/ethereum/go-ethereum && GO111MODULE=off make devtools
+RUN rm -rf /home/go/src/github.com/ethereum/go-ethereum
 
 # test configuration
 ENV ETHEREUM_TEST_ADDRESS=wss://ropsten.infura.io/ws

--- a/packages/dev-images/ci/node.Dockerfile
+++ b/packages/dev-images/ci/node.Dockerfile
@@ -6,7 +6,6 @@ ENV DOCKER true
 
 ENV GOCACHE=/home/.go-build
 ENV GO111MODULE=on
-ENV GOLINTCI_RELEASE=1.16.0
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/home/go
 

--- a/packages/dev-images/ci/node.Dockerfile
+++ b/packages/dev-images/ci/node.Dockerfile
@@ -1,12 +1,14 @@
 FROM node:lts
 
+WORKDIR /home
+
 ENV DOCKER true
 
-ENV GOCACHE=$HOME/.go-build
+ENV GOCACHE=/home/.go-build
 ENV GO111MODULE=on
 ENV GOLINTCI_RELEASE=1.16.0
 ENV GOROOT=/usr/local/go
-ENV GOPATH=$HOME/go
+ENV GOPATH=/home/go
 
 RUN apt-get update
 RUN apt-get install -y netcat build-essential libudev-dev jq
@@ -18,9 +20,9 @@ ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
 RUN go version
 RUN GO111MODULE=off go get -u github.com/go-bindata/go-bindata/...
 
-RUN git clone https://github.com/ethereum/go-ethereum
-RUN cd go-ethereum && git checkout release/1.8 && make devtools
-RUN rm -rf go-ethereum
+RUN git clone -b release/1.8 https://github.com/ethereum/go-ethereum /home/go/src/github.com/ethereum/go-ethereum
+RUN cd /home/go/src/github.com/ethereum/go-ethereum && GO111MODULE=off make devtools
+RUN rm -rf /home/go/src/github.com/ethereum/go-ethereum
 
 RUN yarn global add npm npx ganache-cli typescript prettier npm-cli-login
 

--- a/packages/dev-images/docs/README.md
+++ b/packages/dev-images/docs/README.md
@@ -1,4 +1,4 @@
-# `@kosu/dev-images`
+# Kosu development images
 
 Development and CI docker images and supporting scripts for the Kosu project.
 


### PR DESCRIPTION
## Overview

[Our Google Cloud builds have been failing](https://console.cloud.google.com/cloud-build/builds/1500cf3c-3378-4b2d-825b-595630c4ccfe?project=kosu-io&organizationId=401452478378) due to issues with the Dockerfile steps that install `go-ethereum` binaries ultimately related to the `GOPATH` and go modules from 1.11. I'm not sure why it arose recently, since we've been on go >1.11 for a while).

A new method that handles lack of GO111MODULE support for `go-ethereum` should fix this issue. All builds for geth are done from `/home/go/github.com/ethereum/go-ethereum`, since apparently they don't support go modules.