### PR TITLE
go-kosu: use a list type to store orders

### DIFF
--- a/packages/go-kosu/abci/client.go
+++ b/packages/go-kosu/abci/client.go
@@ -186,7 +186,7 @@ func (c *Client) QueryTotalOrders() (uint64, error) {
 
 // QueryLatestOrders queries a collection (subspace) of orders in the `orders` store.
 func (c *Client) QueryLatestOrders() ([]types.TransactionOrder, error) {
-	KVs, err := c.querySubSpace("orders", []byte(cosmos.OrderKeyPrefix))
+	KVs, err := c.querySubSpace("orders", cosmos.ElemKey(0))
 	if err != nil {
 		return nil, err
 	}

--- a/packages/go-kosu/abci/client.go
+++ b/packages/go-kosu/abci/client.go
@@ -177,7 +177,7 @@ func (c *Client) QueryValidator(addr string) (*types.Validator, error) {
 // QueryTotalOrders performs a ABCI Query to "/chain/totalorders"
 func (c *Client) QueryTotalOrders() (uint64, error) {
 	var num uint64
-	if err := c.Query("/store/chain/key", []byte("totalorders"), &num); err != nil {
+	if err := c.Query("/store/orders/key", cosmos.LengthKey(), &num); err != nil {
 		return 0, err
 	}
 

--- a/packages/go-kosu/store/cosmos/list.go
+++ b/packages/go-kosu/store/cosmos/list.go
@@ -1,0 +1,115 @@
+package cosmos
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/ParadigmFoundation/kosu-monorepo/packages/go-kosu/store"
+)
+
+type panicCodec struct {
+	store.Codec
+}
+
+func (cdc *panicCodec) MustEncode(ptr interface{}) []byte {
+	bz, err := cdc.Encode(ptr)
+	if err != nil {
+		panic(err)
+	}
+	return bz
+}
+
+func (cdc *panicCodec) MustDecode(bz []byte, ptr interface{}) {
+	if err := cdc.Decode(bz, ptr); err != nil {
+		panic(err)
+	}
+}
+
+// LengthKey is the key for the length of the list
+func LengthKey() []byte {
+	return []byte{0x00}
+}
+
+// ElemKey is the key for the elements of the list
+func ElemKey(index uint64) []byte {
+	return append([]byte{0x01}, []byte(fmt.Sprintf("%020d", index))...)
+}
+
+// List defines an integer indexable mapper
+// It panics when the element type cannot be (un/)marshalled by the codec
+type List struct {
+	cdc   *panicCodec
+	store types.KVStore
+}
+
+// NewList constructs new List
+func NewList(cdc store.Codec, store types.KVStore) *List {
+	return &List{
+		cdc:   &panicCodec{cdc},
+		store: store,
+	}
+}
+
+// Len returns the length of the list
+// The user should check Len() before doing any actions
+func (m List) Len() (res uint64) {
+	bz := m.store.Get(LengthKey())
+	if bz == nil {
+		return 0
+	}
+
+	m.cdc.MustDecode(bz, &res)
+	return
+}
+
+// Get returns the element by its index
+func (m List) Get(index uint64, ptr interface{}) error {
+	bz := m.store.Get(ElemKey(index))
+	return m.cdc.Decode(bz, ptr)
+}
+
+// Set stores the element to the given position
+// Setting element out of range will break length counting
+// Use Push() instead of Set() to append a new element
+func (m List) Set(index uint64, value interface{}) {
+	bz := m.cdc.MustEncode(value)
+	m.store.Set(ElemKey(index), bz)
+}
+
+// Delete deletes the element in the given position
+// Other elements' indices are preserved after deletion
+// Panics when the index is out of range
+func (m List) Delete(index uint64) {
+	m.store.Delete(ElemKey(index))
+}
+
+// Push inserts the element to the end of the list
+// It will increase the length when it is called
+func (m List) Push(value interface{}) {
+	length := m.Len()
+	m.Set(length, value)
+	m.store.Set(LengthKey(), m.cdc.MustEncode(length+1))
+}
+
+// Iterate is used to iterate over all existing elements in the list
+// Return true in the continuation to break
+// Using it with Get() will return the same one with the provided element
+func (m List) Iterate(fn func(uint64) bool) {
+	iter := types.KVStorePrefixIterator(m.store, []byte{0x01})
+	defer iter.Close()
+	for ; iter.Valid(); iter.Next() {
+		k := iter.Key()
+		s := string(k[len(k)-20:])
+
+		index, err := strconv.ParseUint(s, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+
+		if fn(index) {
+			break
+		}
+	}
+}

--- a/packages/go-kosu/store/store.go
+++ b/packages/go-kosu/store/store.go
@@ -25,7 +25,6 @@ type Store interface {
 	SetLastEvent(uint64)
 
 	TotalOrders() uint64
-	SetTotalOrders(uint64)
 	SetOrder(tx *types.TransactionOrder, limit int)
 	GetOrders() []types.TransactionOrder
 

--- a/packages/go-kosu/store/storetest/testing.go
+++ b/packages/go-kosu/store/storetest/testing.go
@@ -25,7 +25,6 @@ func TestSuite(t *testing.T, f Factory) {
 		{"RoundInfo", TestRoundInfo},
 		{"ConsensusParams", TestConsensusParams},
 		{"LastEvent", TestLastEvent},
-		{"TotalOrders", TestTotalOrders},
 		{"Witness", TestWitness},
 		{"Poster", TestPoster},
 		{"Validator", TestValidator},
@@ -66,16 +65,6 @@ func TestLastEvent(t *testing.T, s store.Store) {
 	s.SetLastEvent(lastEvent)
 
 	assert.Equal(t, lastEvent, s.LastEvent())
-}
-
-// TestTotalOrders verifies the LastTotalOrders storage behavior
-func TestTotalOrders(t *testing.T, s store.Store) {
-	s.SetTotalOrders(1)
-	s.SetTotalOrders(2)
-	s.SetTotalOrders(3)
-	s.SetTotalOrders(4)
-
-	assert.Equal(t, uint64(4), s.TotalOrders())
 }
 
 // TestWitness verifies the Witness storage behavior


### PR DESCRIPTION
This PR introduces a List (taken from cosmos-sdk code) type to store and retrieve the orders from the strore.