### PR TITLE
dev-images: update golang and node.js CI images

### DIFF
--- a/packages/dev-images/ci/go-kosu.Dockerfile
+++ b/packages/dev-images/ci/go-kosu.Dockerfile
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 ENV GOROOT=/usr/local/go
 ENV GOPATH=/home/go
 
-ENV GOLINTCI_RELEASE=1.18.0
+ENV GOLINTCI_RELEASE=1.21.0
 
 # setup
 RUN apt-get update
@@ -24,5 +24,5 @@ ENV ETHEREUM_TEST_ADDRESS=wss://ropsten.infura.io/ws
 # install go-bindata
 RUN GO111MODULE=off go get -u github.com/go-bindata/go-bindata/...
 
-# install golintci
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v${GOLINTCI_RELEASE}
+# install golintcis
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v$GOLINTCI_RELEASE

--- a/packages/dev-images/ci/go-kosu.Dockerfile
+++ b/packages/dev-images/ci/go-kosu.Dockerfile
@@ -24,5 +24,5 @@ ENV ETHEREUM_TEST_ADDRESS=wss://ropsten.infura.io/ws
 # install go-bindata
 RUN GO111MODULE=off go get -u github.com/go-bindata/go-bindata/...
 
-# install golintcis
+# install golintci
 RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b /usr/bin v$GOLINTCI_RELEASE

--- a/packages/dev-images/ci/node.Dockerfile
+++ b/packages/dev-images/ci/node.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts
+FROM node:10
 
 WORKDIR /home
 


### PR DESCRIPTION
## Overview

- Fixing a `golangci-lint` install issue in `go-kosu-ci`
- Downgrade from Node.js 12 LTS to Node.js 10 LTS for better compatibility 