### PR TITLE
go-kosu: bump version v0.5.0

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+## v0.5.0
+
 -   Fix Order store I/O overhead
 -   Fix wrong initial validators power calculations
 -   Add --validator family flags to optionally start as a validator node

--- a/packages/go-kosu/package.json
+++ b/packages/go-kosu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@kosu/go-kosu",
     "private": true,
-    "version": "0.4.0",
+    "version": "v0.5.0",
     "description": "Package file used to configure go-kosu builds with up-to-date contract addresses",
     "repository": "https://github.com/ParadigmFoundation/kosu-monorepo/blob/master/packages/go-kosu",
     "license": "MIT",


### PR DESCRIPTION
once this is merged I'll push `:v0.5.0` tag