### PR TITLE
node-client: undo serialization hack from client bug

### DIFF
--- a/packages/kosu-node-client/docs/README.md
+++ b/packages/kosu-node-client/docs/README.md
@@ -1,6 +1,6 @@
-> **[node-client](README.md)**
+[Kosu Node Client](README.md) › [Globals](globals.md)
 
-[Globals](globals.md) /
+# Kosu Node Client
 
 # Node Client
 

--- a/packages/kosu-node-client/docs/classes/nodeclient.md
+++ b/packages/kosu-node-client/docs/classes/nodeclient.md
@@ -57,7 +57,7 @@ View the Kosu RPC documentation [here.](https://docs.kosu.io/go-kosu/kosu_rpc.ht
 
 \+ **new NodeClient**(`url`: string, `options?`: WebsocketProviderOptions): _[NodeClient](nodeclient.md)_
 
-_Defined in [node_client.ts:69](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L69)_
+_Defined in [node_client.ts:69](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L69)_
 
 Create a new NodeClient (`node`) via a connection to a Kosu node serving
 the Kosu JSONRPC/WebSocket.
@@ -84,7 +84,7 @@ const node = new NodeClient("wss://localhost:14342", { timeout: 1000 });
 
 ▪ **NODE_ID_HASH_OFFSET**: _number_ = 20
 
-_Defined in [node_client.ts:39](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L39)_
+_Defined in [node_client.ts:39](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L39)_
 
 Kosu validator node IDs are the first 20 bytes of the SHA-256 hash of the
 public key.
@@ -95,7 +95,7 @@ public key.
 
 ▪ **PUBLIC_KEY_LENGTH**: _number_ = 32
 
-_Defined in [node_client.ts:33](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L33)_
+_Defined in [node_client.ts:33](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L33)_
 
 Kosu validator public key's are 32 bytes long.
 
@@ -103,9 +103,9 @@ Kosu validator public key's are 32 bytes long.
 
 ### addOrders
 
-▸ **addOrders**(...`orders`: any[]): _Promise‹OrderValidationResult[]›_
+▸ **addOrders**(...`orders`: PostableOrder[]): _Promise‹OrderValidationResult[]›_
 
-_Defined in [node_client.ts:101](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L101)_
+_Defined in [node_client.ts:101](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L101)_
 
 See [`kosu_addOrders`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#addorders)
 
@@ -117,9 +117,9 @@ See the `posterRegistry.registerTokens()` method to bond KOSU.
 
 **Parameters:**
 
-| Name        | Type  | Description                                           |
-| ----------- | ----- | ----------------------------------------------------- |
-| `...orders` | any[] | Orders to submit to the node as subsequent arguments. |
+| Name        | Type            | Description                                           |
+| ----------- | --------------- | ----------------------------------------------------- |
+| `...orders` | PostableOrder[] | Orders to submit to the node as subsequent arguments. |
 
 **Returns:** _Promise‹OrderValidationResult[]›_
 
@@ -132,7 +132,7 @@ ID's of the accepted orders.
 
 ▸ **latestHeight**(): _Promise‹number›_
 
-_Defined in [node_client.ts:112](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L112)_
+_Defined in [node_client.ts:112](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L112)_
 
 See [`kosu_latestHeight`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#latestheight)
 
@@ -148,7 +148,7 @@ The most recent Kosu block number.
 
 ▸ **numberPosters**(): _Promise‹number›_
 
-_Defined in [node_client.ts:123](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L123)_
+_Defined in [node_client.ts:123](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L123)_
 
 See [`kosu_numberPosters`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#numberposters)
 
@@ -164,7 +164,7 @@ The total number of poster accounts the node is tracking.
 
 ▸ **queryPoster**(`address`: string): _Promise‹Poster›_
 
-_Defined in [node_client.ts:135](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L135)_
+_Defined in [node_client.ts:135](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L135)_
 
 See [`kosu_queryPoster`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#queryposter)
 
@@ -187,7 +187,7 @@ Balance and order limit data for the specified poster account.
 
 ▸ **queryValidator**(`nodeId`: string): _Promise‹Validator›_
 
-_Defined in [node_client.ts:154](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L154)_
+_Defined in [node_client.ts:154](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L154)_
 
 See [`kosu_queryValidator`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#queryvalidator)
 
@@ -214,7 +214,7 @@ Information about the requested validator (see `Validator`).
 
 ▸ **remainingLimit**(): _Promise‹number›_
 
-_Defined in [node_client.ts:170](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L170)_
+_Defined in [node_client.ts:170](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L170)_
 
 See [`kosu_remainingLimit`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#remaininglimit)
 
@@ -232,7 +232,7 @@ The unutilized order bandwidth for the current period.
 
 ▸ **roundInfo**(): _Promise‹RoundInfo›_
 
-_Defined in [node_client.ts:182](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L182)_
+_Defined in [node_client.ts:182](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L182)_
 
 See [`kosu_roundInfo`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#roundinfo)
 
@@ -249,7 +249,7 @@ Information about the current rebalance period.
 
 ▸ **subscribeToBlocks**(`cb`: function): _Promise‹string›_
 
-_Defined in [node_client.ts:238](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L238)_
+_Defined in [node_client.ts:238](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L238)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -282,7 +282,7 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ▸ **subscribeToOrders**(`cb`: function): _Promise‹string›_
 
-_Defined in [node_client.ts:223](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L223)_
+_Defined in [node_client.ts:223](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L223)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -297,13 +297,13 @@ orders each time they are included in a Kosu block.
 
 A callback function to handle each array of new orders.
 
-▸ (`order`: any): _void_
+▸ (`order`: PostableOrder): _void_
 
 **Parameters:**
 
-| Name    | Type |
-| ------- | ---- |
-| `order` | any  |
+| Name    | Type          |
+| ------- | ------------- |
+| `order` | PostableOrder |
 
 **Returns:** _Promise‹string›_
 
@@ -315,7 +315,7 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ▸ **subscribeToRebalances**(`cb`: function): _Promise‹string›_
 
-_Defined in [node_client.ts:253](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L253)_
+_Defined in [node_client.ts:253](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L253)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -348,7 +348,7 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ▸ **totalOrders**(): _Promise‹number›_
 
-_Defined in [node_client.ts:195](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L195)_
+_Defined in [node_client.ts:195](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L195)_
 
 See [`kosu_totalOrders`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#totalorders)
 
@@ -365,7 +365,7 @@ The total number of orders posted since network genesis.
 
 ▸ **unsubscribe**(`subscriptionId`: string): _Promise‹void›_
 
-_Defined in [node_client.ts:262](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L262)_
+_Defined in [node_client.ts:262](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L262)_
 
 Cancel an active subscription.
 
@@ -383,7 +383,7 @@ Cancel an active subscription.
 
 ▸ **validators**(): _Promise‹Validator[]›_
 
-_Defined in [node_client.ts:207](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L207)_
+_Defined in [node_client.ts:207](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L207)_
 
 See [`kosu_validators`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#validators)
 
@@ -400,7 +400,7 @@ Information about all active Kosu validators (see `Validator`).
 
 ▸ **publicKeyToNodeId**(`publicKey`: string): _string_
 
-_Defined in [node_client.ts:52](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L52)_
+_Defined in [node_client.ts:52](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L52)_
 
 Convert a Kosu/Tendermint public key to the corresponding node ID.
 
@@ -422,7 +422,7 @@ The node ID (tendermint "address") for that public key.
 
 ### ▪ **DEFAULT_OPTIONS**: _object_
 
-_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L28)_
+_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L28)_
 
 The default options specify a connection timeout of 3s, all other defaults
 are inherited from `WebsocketProviderOptions`.
@@ -431,4 +431,4 @@ are inherited from `WebsocketProviderOptions`.
 
 • **timeout**: _number_ = 3000
 
-_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L28)_
+_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/b693e207/packages/kosu-node-client/src/node_client.ts#L28)_

--- a/packages/kosu-node-client/docs/classes/nodeclient.md
+++ b/packages/kosu-node-client/docs/classes/nodeclient.md
@@ -1,6 +1,4 @@
-> **[node-client](../README.md)**
-
-[Globals](../globals.md) / [NodeClient](nodeclient.md) /
+[Kosu Node Client](../README.md) › [Globals](../globals.md) › [NodeClient](nodeclient.md)
 
 # Class: NodeClient
 
@@ -57,9 +55,9 @@ View the Kosu RPC documentation [here.](https://docs.kosu.io/go-kosu/kosu_rpc.ht
 
 ### constructor
 
-\+ **new NodeClient**(`url`: string, `options?`: `WebsocketProviderOptions`): _[NodeClient](nodeclient.md)_
+\+ **new NodeClient**(`url`: string, `options?`: WebsocketProviderOptions): _[NodeClient](nodeclient.md)_
 
-Defined in NodeClient.ts:70
+_Defined in [node_client.ts:69](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L69)_
 
 Create a new NodeClient (`node`) via a connection to a Kosu node serving
 the Kosu JSONRPC/WebSocket.
@@ -73,10 +71,10 @@ const node = new NodeClient("wss://localhost:14342", { timeout: 1000 });
 
 **Parameters:**
 
-| Name       | Type                       | Description                                             |
-| ---------- | -------------------------- | ------------------------------------------------------- |
-| `url`      | string                     | Full URL to the Kosu node's WebSocket JSONRPC endpoint. |
-| `options?` | `WebsocketProviderOptions` | Options to provide the underlying `WebSocketProvider`.  |
+| Name       | Type                     | Description                                             |
+| ---------- | ------------------------ | ------------------------------------------------------- |
+| `url`      | string                   | Full URL to the Kosu node's WebSocket JSONRPC endpoint. |
+| `options?` | WebsocketProviderOptions | Options to provide the underlying `WebSocketProvider`.  |
 
 **Returns:** _[NodeClient](nodeclient.md)_
 
@@ -86,7 +84,7 @@ const node = new NodeClient("wss://localhost:14342", { timeout: 1000 });
 
 ▪ **NODE_ID_HASH_OFFSET**: _number_ = 20
 
-Defined in NodeClient.ts:39
+_Defined in [node_client.ts:39](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L39)_
 
 Kosu validator node IDs are the first 20 bytes of the SHA-256 hash of the
 public key.
@@ -97,7 +95,7 @@ public key.
 
 ▪ **PUBLIC_KEY_LENGTH**: _number_ = 32
 
-Defined in NodeClient.ts:33
+_Defined in [node_client.ts:33](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L33)_
 
 Kosu validator public key's are 32 bytes long.
 
@@ -105,9 +103,9 @@ Kosu validator public key's are 32 bytes long.
 
 ### addOrders
 
-▸ **addOrders**(...`orders`: any[]): _`Promise<OrderValidationResult[]>`_
+▸ **addOrders**(...`orders`: any[]): _Promise‹OrderValidationResult[]›_
 
-Defined in NodeClient.ts:102
+_Defined in [node_client.ts:101](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L101)_
 
 See [`kosu_addOrders`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#addorders)
 
@@ -123,7 +121,7 @@ See the `posterRegistry.registerTokens()` method to bond KOSU.
 | ----------- | ----- | ----------------------------------------------------- |
 | `...orders` | any[] | Orders to submit to the node as subsequent arguments. |
 
-**Returns:** _`Promise<OrderValidationResult[]>`_
+**Returns:** _Promise‹OrderValidationResult[]›_
 
 Validation results from the Kosu node, and/or the transaction
 ID's of the accepted orders.
@@ -132,15 +130,15 @@ ID's of the accepted orders.
 
 ### latestHeight
 
-▸ **latestHeight**(): _`Promise<number>`_
+▸ **latestHeight**(): _Promise‹number›_
 
-Defined in NodeClient.ts:113
+_Defined in [node_client.ts:112](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L112)_
 
 See [`kosu_latestHeight`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#latestheight)
 
 Get the height of the most recently committed and finalized Kosu block.
 
-**Returns:** _`Promise<number>`_
+**Returns:** _Promise‹number›_
 
 The most recent Kosu block number.
 
@@ -148,15 +146,15 @@ The most recent Kosu block number.
 
 ### numberPosters
 
-▸ **numberPosters**(): _`Promise<number>`_
+▸ **numberPosters**(): _Promise‹number›_
 
-Defined in NodeClient.ts:124
+_Defined in [node_client.ts:123](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L123)_
 
 See [`kosu_numberPosters`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#numberposters)
 
 Get the total number registered posters from the Kosu node.
 
-**Returns:** _`Promise<number>`_
+**Returns:** _Promise‹number›_
 
 The total number of poster accounts the node is tracking.
 
@@ -164,9 +162,9 @@ The total number of poster accounts the node is tracking.
 
 ### queryPoster
 
-▸ **queryPoster**(`address`: string): _`Promise<Poster>`_
+▸ **queryPoster**(`address`: string): _Promise‹Poster›_
 
-Defined in NodeClient.ts:136
+_Defined in [node_client.ts:135](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L135)_
 
 See [`kosu_queryPoster`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#queryposter)
 
@@ -179,7 +177,7 @@ about a specified poster account.
 | --------- | ------ |
 | `address` | string |
 
-**Returns:** _`Promise<Poster>`_
+**Returns:** _Promise‹Poster›_
 
 Balance and order limit data for the specified poster account.
 
@@ -187,9 +185,9 @@ Balance and order limit data for the specified poster account.
 
 ### queryValidator
 
-▸ **queryValidator**(`nodeId`: string): _`Promise<Validator>`_
+▸ **queryValidator**(`nodeId`: string): _Promise‹Validator›_
 
-Defined in NodeClient.ts:157
+_Defined in [node_client.ts:154](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L154)_
 
 See [`kosu_queryValidator`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#queryvalidator)
 
@@ -206,7 +204,7 @@ public key to it's node ID.
 | -------- | ------ |
 | `nodeId` | string |
 
-**Returns:** _`Promise<Validator>`_
+**Returns:** _Promise‹Validator›_
 
 Information about the requested validator (see `Validator`).
 
@@ -214,9 +212,9 @@ Information about the requested validator (see `Validator`).
 
 ### remainingLimit
 
-▸ **remainingLimit**(): _`Promise<number>`_
+▸ **remainingLimit**(): _Promise‹number›_
 
-Defined in NodeClient.ts:174
+_Defined in [node_client.ts:170](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L170)_
 
 See [`kosu_remainingLimit`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#remaininglimit)
 
@@ -224,7 +222,7 @@ Get the total number of orders that _may_ be posted this period. It is
 equal to the sum of the unutilized bandwidth allocation for each poster
 account for the current rebalance period.
 
-**Returns:** _`Promise<number>`_
+**Returns:** _Promise‹number›_
 
 The unutilized order bandwidth for the current period.
 
@@ -232,16 +230,16 @@ The unutilized order bandwidth for the current period.
 
 ### roundInfo
 
-▸ **roundInfo**(): _`Promise<RoundInfo>`_
+▸ **roundInfo**(): _Promise‹RoundInfo›_
 
-Defined in NodeClient.ts:186
+_Defined in [node_client.ts:182](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L182)_
 
 See [`kosu_roundInfo`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#roundinfo)
 
 Get the current rebalance period number, starting Ethereum block, ending
 Ethereum block, and the maximum number of orders for the period.
 
-**Returns:** _`Promise<RoundInfo>`_
+**Returns:** _Promise‹RoundInfo›_
 
 Information about the current rebalance period.
 
@@ -249,9 +247,9 @@ Information about the current rebalance period.
 
 ### subscribeToBlocks
 
-▸ **subscribeToBlocks**(`cb`: function): _`Promise<string>`_
+▸ **subscribeToBlocks**(`cb`: function): _Promise‹string›_
 
-Defined in NodeClient.ts:242
+_Defined in [node_client.ts:238](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L238)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -274,7 +272,7 @@ A callback function to handle new rebalance information.
 | ------- | ---- |
 | `block` | any  |
 
-**Returns:** _`Promise<string>`_
+**Returns:** _Promise‹string›_
 
 A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`).
 
@@ -282,9 +280,9 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ### subscribeToOrders
 
-▸ **subscribeToOrders**(`cb`: function): _`Promise<string>`_
+▸ **subscribeToOrders**(`cb`: function): _Promise‹string›_
 
-Defined in NodeClient.ts:227
+_Defined in [node_client.ts:223](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L223)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -307,7 +305,7 @@ A callback function to handle each array of new orders.
 | ------- | ---- |
 | `order` | any  |
 
-**Returns:** _`Promise<string>`_
+**Returns:** _Promise‹string›_
 
 A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`).
 
@@ -315,9 +313,9 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ### subscribeToRebalances
 
-▸ **subscribeToRebalances**(`cb`: function): _`Promise<string>`_
+▸ **subscribeToRebalances**(`cb`: function): _Promise‹string›_
 
-Defined in NodeClient.ts:257
+_Defined in [node_client.ts:253](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L253)_
 
 Read about Kosu subscriptions [here](https://docs.kosu.io/go-kosu/kosu_rpc.html#subscriptions).
 
@@ -332,15 +330,15 @@ information (starting block, ending block, etc.).
 
 A callback function to handle new rebalance information.
 
-▸ (`roundInfo`: `RoundInfo`): _void_
+▸ (`roundInfo`: RoundInfo): _void_
 
 **Parameters:**
 
-| Name        | Type        |
-| ----------- | ----------- |
-| `roundInfo` | `RoundInfo` |
+| Name        | Type      |
+| ----------- | --------- |
+| `roundInfo` | RoundInfo |
 
-**Returns:** _`Promise<string>`_
+**Returns:** _Promise‹string›_
 
 A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`).
 
@@ -348,16 +346,16 @@ A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`
 
 ### totalOrders
 
-▸ **totalOrders**(): _`Promise<number>`_
+▸ **totalOrders**(): _Promise‹number›_
 
-Defined in NodeClient.ts:199
+_Defined in [node_client.ts:195](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L195)_
 
 See [`kosu_totalOrders`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#totalorders)
 
 Get the total number of orders that have been processed by the network
 since genesis.
 
-**Returns:** _`Promise<number>`_
+**Returns:** _Promise‹number›_
 
 The total number of orders posted since network genesis.
 
@@ -365,9 +363,9 @@ The total number of orders posted since network genesis.
 
 ### unsubscribe
 
-▸ **unsubscribe**(`subscriptionId`: string): _`Promise<void>`_
+▸ **unsubscribe**(`subscriptionId`: string): _Promise‹void›_
 
-Defined in NodeClient.ts:266
+_Defined in [node_client.ts:262](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L262)_
 
 Cancel an active subscription.
 
@@ -377,22 +375,22 @@ Cancel an active subscription.
 | ---------------- | ------ | --------------------------------------- |
 | `subscriptionId` | string | The UUID of the subscription to cancel. |
 
-**Returns:** _`Promise<void>`_
+**Returns:** _Promise‹void›_
 
 ---
 
 ### validators
 
-▸ **validators**(): _`Promise<Validator[]>`_
+▸ **validators**(): _Promise‹Validator[]›_
 
-Defined in NodeClient.ts:211
+_Defined in [node_client.ts:207](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L207)_
 
 See [`kosu_validators`.](https://docs.kosu.io/go-kosu/kosu_rpc.html#validators)
 
 Get finalized (committed into current state) information about the current
 full validator set. Returns the full set (not paginated).
 
-**Returns:** _`Promise<Validator[]>`_
+**Returns:** _Promise‹Validator[]›_
 
 Information about all active Kosu validators (see `Validator`).
 
@@ -402,7 +400,7 @@ Information about all active Kosu validators (see `Validator`).
 
 ▸ **publicKeyToNodeId**(`publicKey`: string): _string_
 
-Defined in NodeClient.ts:52
+_Defined in [node_client.ts:52](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L52)_
 
 Convert a Kosu/Tendermint public key to the corresponding node ID.
 
@@ -424,7 +422,7 @@ The node ID (tendermint "address") for that public key.
 
 ### ▪ **DEFAULT_OPTIONS**: _object_
 
-Defined in NodeClient.ts:28
+_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L28)_
 
 The default options specify a connection timeout of 3s, all other defaults
 are inherited from `WebsocketProviderOptions`.
@@ -433,4 +431,4 @@ are inherited from `WebsocketProviderOptions`.
 
 • **timeout**: _number_ = 3000
 
-Defined in NodeClient.ts:28
+_Defined in [node_client.ts:28](https://github.com/ParadigmFoundation/kosu-monorepo/blob/c80e6429/packages/kosu-node-client/src/node_client.ts#L28)_

--- a/packages/kosu-node-client/docs/globals.md
+++ b/packages/kosu-node-client/docs/globals.md
@@ -1,8 +1,6 @@
-> **[node-client](README.md)**
+[Kosu Node Client](README.md) › [Globals](globals.md)
 
-[Globals](globals.md) /
-
-# node-client
+# Kosu Node Client
 
 ## Index
 

--- a/packages/kosu-node-client/src/index.ts
+++ b/packages/kosu-node-client/src/index.ts
@@ -1,1 +1,3 @@
-export { NodeClient } from "./NodeClient";
+export { NodeClient } from "./node_client";
+export { OrderValidationResult, Validator, Poster, RoundInfo } from "@kosu/types";
+export { BigNumber } from "@0x/utils";

--- a/packages/kosu-node-client/src/index.ts
+++ b/packages/kosu-node-client/src/index.ts
@@ -1,3 +1,3 @@
 export { NodeClient } from "./node_client";
-export { OrderValidationResult, Validator, Poster, RoundInfo } from "@kosu/types";
+export { OrderValidationResult, Validator, Poster, RoundInfo, PostableOrder, Order } from "@kosu/types";
 export { BigNumber } from "@0x/utils";

--- a/packages/kosu-node-client/src/node_client.ts
+++ b/packages/kosu-node-client/src/node_client.ts
@@ -1,6 +1,6 @@
 import { BigNumber } from "@0x/utils";
 import { WebsocketProvider, WebsocketProviderOptions } from "@0x/web3-providers-fork";
-import { OrderValidationResult, Poster, RoundInfo, Validator } from "@kosu/types";
+import { OrderValidationResult, PostableOrder, Poster, RoundInfo, Validator } from "@kosu/types";
 import assert from "assert";
 import { createHash } from "crypto";
 import { isFunction, isString } from "lodash";
@@ -98,7 +98,7 @@ export class NodeClient {
      * @returns Validation results from the Kosu node, and/or the transaction
      * ID's of the accepted orders.
      */
-    public async addOrders(...orders: any[]): Promise<OrderValidationResult[]> {
+    public async addOrders(...orders: PostableOrder[]): Promise<OrderValidationResult[]> {
         return this._call("kosu_addOrders", ...orders);
     }
 
@@ -220,7 +220,7 @@ export class NodeClient {
      * @param cb A callback function to handle each array of new orders.
      * @returns A UUID that can be used to cancel the new subscription (see `node.unsubscribe()`).
      */
-    public async subscribeToOrders(cb: (order: any) => void): Promise<string> {
+    public async subscribeToOrders(cb: (order: PostableOrder) => void): Promise<string> {
         return this._subscribe("newOrders", (res: any) => cb(res.result));
     }
 

--- a/packages/kosu-node-client/src/node_client.ts
+++ b/packages/kosu-node-client/src/node_client.ts
@@ -62,8 +62,7 @@ export class NodeClient {
     private static _convertValidatorData(...rawValidators: any[]): Validator[] {
         const validators = [];
         for (const validator of rawValidators) {
-            // HACK: protobuf nests the balance as `balance: "value: N"`
-            const balance = new BigNumber(validator.balance.split(": ")[1]);
+            const balance = new BigNumber(validator.balance);
             validators.push({ ...validator, balance });
         }
         return validators;
@@ -136,9 +135,7 @@ export class NodeClient {
     public async queryPoster(address: string): Promise<Poster> {
         assert(/^0x[a-fA-F0-9]{40}$/.test(address), "invalid Ethereum address string");
         const raw = await this._call("kosu_queryPoster", address.toLowerCase());
-
-        // HACK: dealing with protobuf `balance: 'value: N'` encoding
-        const balance = new BigNumber(raw.balance.split(": ")[1]);
+        const balance = new BigNumber(raw.balance);
         return { ...raw, balance };
     }
 
@@ -157,7 +154,6 @@ export class NodeClient {
     public async queryValidator(nodeId: string): Promise<Validator> {
         assert(/^[a-fA-F0-9]{40}$/.test(nodeId), "invalid nodeId string");
 
-        // hack: dealing with protobuf decoding issues
         const raw = await this._call("kosu_queryValidator", nodeId);
         return NodeClient._convertValidatorData(raw)[0];
     }


### PR DESCRIPTION
## Overview

- Removes an extra parsing step from Validator and Poster queries that was an artifact of a bug from `go-kosu` protobuf serialization pre-0.4.
- Exports relevant types from @kosu/types
- Update a filename
- Regenerate documentation