### PR TITLE
node-client: release v0.5.0

### DIFF
--- a/packages/kosu-node-client/package.json
+++ b/packages/kosu-node-client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@kosu/node-client",
-    "version": "0.3.0",
-    "description": "JavaScript module for connecting with Kosu.",
+    "version": "0.5.0",
+    "description": "JavaScript module for connecting interacting with the Kosu JSONRPC.",
     "main": "dist/src/index.js",
     "license": "MIT",
     "scripts": {
@@ -31,7 +31,7 @@
         "@babel/core": "^7.4.4",
         "@kosu/tsc-config": "^0.1.0",
         "@kosu/tslint-config": "^0.0.5",
-        "@kosu/types": "^0.3.0",
+        "@kosu/types": "^0.3.1",
         "camelcase-keys": "^6.1.0",
         "lodash": "^4.17.15",
         "uuid": "^3.3.3"


### PR DESCRIPTION
## Overview

Bump `@kosu/node-client` to `v0.5.0`

From now on, the version of `@kosu/node-client` should line up with the version of `@kosu/go-kosu` to ensure and indicate compatibility.