### PR TITLE
test-helpers: disable linter for specific lines

### DIFF
--- a/packages/kosu-test-helpers/src/index.ts
+++ b/packages/kosu-test-helpers/src/index.ts
@@ -337,6 +337,8 @@ export class TestHelpers {
         end: number,
         options: { win?: BigNumber; lose?: BigNumber } = {},
     ): Promise<{ blockNumber: number; pollId: BigNumber }> {
+        // hack: linter fails likely due to some conflicting type definitions
+        // tslint:disable
         const base = await this.web3Wrapper.getBlockNumberAsync();
         const creationBlock = base + 1;
         const commitEnd = creationBlock + start;


### PR DESCRIPTION
## Overview

For some reason, with the new linter rules, we get the following errors from `test-helpers`:
```
ERROR: /Users/hen/GitHub/km/packages/kosu-test-helpers/src/index.ts:341:31 - Operands of '+' operation must either be both strings or both numbers or both bigints, but found any + 1
ERROR: /Users/hen/GitHub/km/packages/kosu-test-helpers/src/index.ts:342:27 - Operands of '+' operation must either be both strings or both numbers or both bigints, but found any + number
ERROR: /Users/hen/GitHub/km/packages/kosu-test-helpers/src/index.ts:343:27 - Operands of '+' operation must either be both strings or both numbers or both bigints, but found any + number
```


The lines in question are fine, but for some reason the type detected for `base` is not being used by the linter. We should address this and remove the two comment lines added in this PR at a future date.

```typescript
const base = await this.web3Wrapper.getBlockNumberAsync();
const creationBlock = base + 1;
const commitEnd = creationBlock + start;
const revealEnd = commitEnd + end;
```