### PR TITLE
go-kosu: Add `abci` subcommmand

### DIFF
--- a/packages/go-kosu/CHANGELOG.md
+++ b/packages/go-kosu/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## v0.6.0
+
+-   Add `abci` subcommand
+
 ## v0.5.0
 
 -   Fix Order store I/O overhead

--- a/packages/go-kosu/abci/cli/abci.go
+++ b/packages/go-kosu/abci/cli/abci.go
@@ -1,0 +1,1 @@
+package cli

--- a/packages/go-kosu/cmd/kosud/main.go
+++ b/packages/go-kosu/cmd/kosud/main.go
@@ -38,6 +38,7 @@ func New() *cobra.Command {
 		cli.NewInitCommand(homeFlag),
 		cli.NewStartCommand(homeFlag),
 		cli.NewNodeCommand(homeFlag),
+		cli.NewABCICommand(homeFlag),
 		version.NewCommand(),
 	)
 

--- a/packages/go-kosu/service/service.go
+++ b/packages/go-kosu/service/service.go
@@ -197,6 +197,11 @@ func (s *Service) startFull(ctx context.Context, errCh chan error) error {
 }
 
 func (s *Service) startWitness(ctx context.Context, app *abci.App) error {
+	return StartWitness(ctx, s.WEB3, app, s.Logger)
+}
+
+// StartWitness starts a witness process
+func StartWitness(ctx context.Context, web3 string, app *abci.App, logger tmlog.Logger) error {
 	client, err := app.NewClient()
 	if err != nil {
 		return err
@@ -209,7 +214,7 @@ func (s *Service) startWitness(ctx context.Context, app *abci.App) error {
 
 	ethOpts := witness.DefaultEthereumProviderOpts
 	ethOpts.SnapshotBlock = gen.SnapshotBlock
-	p, err := witness.NewEthereumProviderWithOpts(s.WEB3, ethOpts)
+	p, err := witness.NewEthereumProviderWithOpts(web3, ethOpts)
 	if err != nil {
 		return err
 	}
@@ -218,7 +223,7 @@ func (s *Service) startWitness(ctx context.Context, app *abci.App) error {
 	opts.PeriodLimit = int(gen.ConsensusParams.PeriodLimit)
 	opts.PeriodLength = int(gen.ConsensusParams.PeriodLength)
 	w := witness.New(client, p, opts)
-	return w.WithLogger(s.Logger).Start(ctx)
+	return w.WithLogger(logger).Start(ctx)
 }
 
 func (s *Service) startLite(errCh chan error) error {


### PR DESCRIPTION
At this point it's still tricky to implement the --validator flag here.
This will create a circular dependency between the Witness and the ABCI
server, the witness needs the ABCI server to be started to query rounds, which is
implemented by tendermint and not go-kosu anymore.

There are possible solutions to this problem that I'd explore later.

For now, this is working, and you can alternate, running as a
stand-alone application and then switch to ABCI mode using the same
homedir.

## Testing instructions

This has been tested in our `micro` instance as follows:
In one terminal run
```
kosud abci
```

While it's running run in another terminal
```
tendermint --home ~/.home/kosu node
```

While `kosud abci` will log the `app` module, `tendermint node` will log `consensus` and `state` modules. 