### PR TITLE
genesis-cli: dependency cleanup

### DIFF
--- a/packages/kosu-genesis-cli/package.json
+++ b/packages/kosu-genesis-cli/package.json
@@ -21,14 +21,12 @@
     "dependencies": {
         "@kosu/kosu.js": "^0.3.0",
         "@kosu/migrations": "^0.3.0",
-        "@kosu/system-contracts": "^0.3.0",
         "@kosu/test-helpers": "^0.3.0",
         "@kosu/tsc-config": "^0.1.0",
         "@kosu/tslint-config": "^0.0.5",
         "chalk": "^2.4.2",
         "commander": "^3.0.1",
-        "web3": "1.2.2",
-        "web3-provider": "^1.0.0"
+        "web3": "1.2.2"
     },
     "devDependencies": {
         "@0x/dev-utils": "^2.3.3",

--- a/packages/kosu-genesis-cli/src/cli/cli.ts
+++ b/packages/kosu-genesis-cli/src/cli/cli.ts
@@ -16,7 +16,7 @@ The following options are required:
     -t, --start-time <number>\
 `;
 
-cli.version("0.0.0")
+cli.version(process.env.npm_package_version)
     .description(description)
     .option("-n, --chain-id <name>", "Specify the resulting Kosu chain ID")
     .option("-p, --provider-url <url>", "HTTP Ethereum JSONRPC provider")

--- a/yarn.lock
+++ b/yarn.lock
@@ -17777,14 +17777,6 @@ web3-provider-engine@^15.0.4:
     xhr "^2.2.0"
     xtend "^4.0.1"
 
-web3-provider@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/web3-provider/-/web3-provider-1.0.0.tgz#f4be8545896b9dbb2aa707df0bdf5af80cd2642e"
-  integrity sha512-dbwX8MbYmeRRSiRaGTq/qEYaWnReEkN1Z2p1+BwxSeFdsntvzxgAOVMfgAFr/iwFVPqYtEHMjkh2shi648c0eA==
-  dependencies:
-    "@types/web3" "^1.0.19"
-    web3 "^1.0.0-beta.55"
-
 web3-providers-http@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.2.1.tgz#c93ea003a42e7b894556f7e19dd3540f947f5013"
@@ -17974,7 +17966,7 @@ web3@1.2.1:
     web3-shh "1.2.1"
     web3-utils "1.2.1"
 
-web3@1.2.2, web3@^1.0.0-beta.55, web3@^1.2.1, web3@^1.2.2:
+web3@1.2.2, web3@^1.2.1, web3@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.2.2.tgz#b1b8b69aafdf94cbaeadbb68a8aa1df2ef266aec"
   integrity sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==


### PR DESCRIPTION
## Overview

- Removing un-used dependencies in anticipation of `go-kosu` v0.6 and genesis-cli v0.6