### PR TITLE
genesis-cli: release v2.0.0

### DIFF
--- a/packages/kosu-genesis-cli/package.json
+++ b/packages/kosu-genesis-cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kosu/genesis-cli",
-    "version": "1.2.0",
+    "version": "2.0.0",
     "description": "Simple CLI for snap-shotting Kosu contract system to generate a Kosu network genesis file.",
     "repository": "https://github.com/ParadigmFoundation/kosu-monorepo/blob/master/packages/kosu-genesis-cli",
     "license": "MIT",


### PR DESCRIPTION
## Overview

- Publish `@kosu/genesis-cli` v2.0.0, compatible with `@kosu/go-kosu` v0.6.0