### PR TITLE
Updates to validator slashable stake implementation

### DIFF
--- a/packages/kosu-solidity-tests/test/validator_registry.ts
+++ b/packages/kosu-solidity-tests/test/validator_registry.ts
@@ -8,7 +8,7 @@ import {
     ValidatorRegistryContract,
     VotingContract,
 } from "@kosu/system-contracts";
-import {Challenge, Listing} from "@kosu/types";
+import { Challenge, Listing } from "@kosu/types";
 import { decodeKosuEvents } from "@kosu/utils";
 import { padRight, soliditySha3, stringToHex, toTwosComplement } from "web3-utils";
 
@@ -106,11 +106,9 @@ describe("ValidatorRegistry", async () => {
         before(async () => {
             for (const account of accounts) {
                 await kosuToken.transfer.awaitTransactionSuccessAsync(account, minimumStake.multipliedBy(10));
-                await kosuToken.approve.awaitTransactionSuccessAsync(
-                    treasury.address,
-                    minimumStake.multipliedBy(10),
-                    { from: account },
-                );
+                await kosuToken.approve.awaitTransactionSuccessAsync(treasury.address, minimumStake.multipliedBy(10), {
+                    from: account,
+                });
                 await treasury.deposit.awaitTransactionSuccessAsync(minimumStake.multipliedBy(10), { from: account });
             }
         });
@@ -337,9 +335,18 @@ describe("ValidatorRegistry", async () => {
                 .that.include("listing not accepted");
 
             listingChallenge0DecodedLogs.eventType.should.eq("ValidatorChallenged", "should be a challenged event");
-            listingChallenge0DecodedLogs.challenger.should.eq(accounts[9].toLowerCase(), "ChallengedEvent should be from accounts[9");
-            listingChallenge0DecodedLogs.owner.should.eq(accounts[0].toLowerCase(), "ChallengedEvent should be against accounts[0]");
-            listingChallenge0DecodedLogs.pollId.should.eq(challenge0PollId.toString(), "ChallengedEvent should expose pollId");
+            listingChallenge0DecodedLogs.challenger.should.eq(
+                accounts[9].toLowerCase(),
+                "ChallengedEvent should be from accounts[9",
+            );
+            listingChallenge0DecodedLogs.owner.should.eq(
+                accounts[0].toLowerCase(),
+                "ChallengedEvent should be against accounts[0]",
+            );
+            listingChallenge0DecodedLogs.pollId.should.eq(
+                challenge0PollId.toString(),
+                "ChallengedEvent should expose pollId",
+            );
             listingChallenge0DecodedLogs.details.should.eq(paradigmMarket, "ChallengedEvent should have details");
 
             // 0 failed challenge

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -699,7 +699,7 @@ contract ValidatorRegistry is Ownable {
         eventEmitter.emitEvent("ValidatorChallengeResolved", data, "");
     }
 
-    function _findGeneratorPlaceInList(int value) internal view returns (bytes32 previous, bytes32 next) {
+    function _findGeneratorPlaceInList(int value) internal view returns (bytes32, bytes32) {
         if (_maxGenerator == 0x0) {
             return (0x0, 0x0);
         }
@@ -719,6 +719,8 @@ contract ValidatorRegistry is Ownable {
                 return (gen.previous, gen.self);
             }
         }
+        return (0x0, 0x0);
+        // This case should be unreachable
     }
 
     function _addGeneratorToList(int rewardRate, bytes32 tendermintPublicKey) internal {

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -107,7 +107,7 @@ contract ValidatorRegistry is Ownable {
         challengePeriod = _challengePeriod;
         exitPeriod = _exitPeriod;
         rewardPeriod = _rewardPeriod;
-        exitLockPeriod = _exitLockPeriod; //TODO initialize with this
+        exitLockPeriod = _exitLockPeriod;
         winningVoteLockPeriod = _winningVoteLockPeriod;
         losingVoteLockPeriod = _losingVoteLockPeriod;
     }

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -65,7 +65,7 @@ contract ValidatorRegistry is Ownable {
     uint public exitLockPeriod;
     uint public winningVoteLockPeriod;
     uint public losingVoteLockPeriod;
-    uint public minimumBalance = 500 ether;
+    uint public minimumStake = 500 ether;
     uint public stakeholderProportionPPM = 300000;
     uint public minMaxGenerator = 1 ether / 10;
     uint public maxGeneratorGrowth = 5 ether / 1000;
@@ -217,8 +217,8 @@ contract ValidatorRegistry is Ownable {
         @param details A string value to represent support for claim (commonly an external link).
     */
     function registerListing(bytes32 tendermintPublicKey, uint tokensToStake, int rewardRate, string calldata details) external {
-        //tokensToStake must be greater than or equal to _minimumBalance
-        require(tokensToStake >= minimumBalance, "must register with at least minimum balance");
+        //tokensToStake must be greater than or equal to minimumStake
+        require(tokensToStake >= minimumStake, "must register with at least minimum balance");
 
         //Claim tokens from the treasury
         treasury.claimTokens(msg.sender, tokensToStake);
@@ -542,7 +542,7 @@ contract ValidatorRegistry is Ownable {
         } else if (index == 4) {
             rewardPeriod = value;
         } else if (index == 5) {
-            minimumBalance = value;
+            minimumStake = value;
         } else if (index == 6) {
             stakeholderProportionPPM = value;
         } else if (index == 7) {

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -66,7 +66,7 @@ contract ValidatorRegistry is Ownable {
     uint public winningVoteLockPeriod;
     uint public losingVoteLockPeriod;
     uint public minimumBalance = 500 ether;
-    uint public stakeholderCut = 30; // Will be used as a percent so must be sub 100
+    uint public stakeholderProportionPPM = 300000;
     uint public minMaxGenerator = 1 ether / 10;
     uint public maxGeneratorGrowth = 5 ether / 1000;
     uint public maxMaxGenerator = 2 ether / 10;
@@ -309,7 +309,7 @@ contract ValidatorRegistry is Ownable {
         uint winningOption = voting.winningOption(challenge.pollId);
 
         //calculate the holders cut
-        uint holderCut = listing.stakedBalance.mul(stakeholderCut).div(100);
+        uint holderCut = challenge.balance.mul(stakeholderProportionPPM).div(MILLION);
         challenge.voterTotal = listing.stakedBalance.sub(holderCut);
 
         if (winningOption == 1) {
@@ -546,7 +546,7 @@ contract ValidatorRegistry is Ownable {
         } else if (index == 5) {
             minimumBalance = value;
         } else if (index == 6) {
-            stakeholderCut = value;
+            stakeholderProportionPPM = value;
         } else if (index == 7) {
             minMaxGenerator = value;
         } else if (index == 8) {

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -79,7 +79,7 @@ contract ValidatorRegistry is Ownable {
     bytes32[] public _listingKeys;
     EventEmitter private eventEmitter;
     bytes32 _maxGenerator;
-    mapping(bytes32 => MaxList)_generators;
+    mapping(bytes32 => MaxList) _generators;
 
     uint private MILLION = 1000000;
 

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -81,6 +81,8 @@ contract ValidatorRegistry is Ownable {
     bytes32 _maxGenerator;
     mapping(bytes32 => MaxList)_generators;
 
+    uint private MILLION = 1000000;
+
     /** @dev Initializes the ValidatorRegistry with chain based configuration for pacing and deployed addresses.
         @notice Initializes the ValidatorRegistry with chain based configuration for pacing and deployed addresses.
         @param _treasuryAddress Deployed Treasury address.

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -303,8 +303,6 @@ contract ValidatorRegistry is Ownable {
         //Must be currently challenged and after the end block but not finalized
         require(listing.status == Status.CHALLENGED, "listing is not challenged");
         require(block.number > challenge.challengeEnd, "challenge has not ended");
-        require(!challenge.finalized, "challenge has been finalized"); //TODO this would be a failure in the state machine and perhaps should be rmeoved
-        require(challenge.balance == listing.stakedBalance, "challenge balance has changed"); //TODO this would be a failure in the state machine and perhaps should be rmeoved
 
         uint winningOption = voting.winningOption(challenge.pollId);
 

--- a/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
+++ b/packages/kosu-system-contracts/contracts/validator/ValidatorRegistry.sol
@@ -310,7 +310,7 @@ contract ValidatorRegistry is Ownable {
 
         //calculate the holders cut
         uint holderCut = challenge.balance.mul(stakeholderProportionPPM).div(MILLION);
-        challenge.voterTotal = listing.stakedBalance.sub(holderCut);
+        challenge.voterTotal = challenge.balance.sub(holderCut);
 
         if (winningOption == 1) {
             challenge.passed = true;
@@ -343,7 +343,7 @@ contract ValidatorRegistry is Ownable {
             }
 
             //Challenger lost and has lost the tokens.
-            treasury.confiscate(challenge.challenger, listing.stakedBalance);
+            treasury.confiscate(challenge.challenger, challenge.balance);
 
             //Approve and release tokens to treasury for the listing holder Remaning tokens
             challenge.balance = challenge.balance.sub(holderCut);

--- a/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
+++ b/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
@@ -100,19 +100,19 @@ export class ValidatorRegistry {
     }
 
     /**
-     * Reads the minimum balance
+     * Reads the minimum stake
      */
-    public async minimumBalance(): Promise<BigNumber> {
+    public async minimumStake(): Promise<BigNumber> {
         const contract = await this.getContract();
-        return contract.minimumBalance.callAsync();
+        return contract.minimumStake.callAsync();
     }
 
     /**
-     * Reads the stakeholder cut
+     * Reads the stakeholder proportion
      */
-    public async stakeholderCut(): Promise<BigNumber> {
+    public async stakeholderProportionPPM(): Promise<BigNumber> {
         const contract = await this.getContract();
-        return contract.stakeholderCut.callAsync();
+        return contract.stakeholderProportionPPM.callAsync();
     }
 
     /**

--- a/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
+++ b/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
@@ -260,9 +260,10 @@ export class ValidatorRegistry {
         const listing: Listing = await this.getListing(_pubKey);
         const approval: BigNumber = await this.treasury.treasuryAllowance();
         const currentBalance: BigNumber = await this.treasury.currentBalance(this.coinbase);
+        const challengeableBalance: BigNumber = listing.stakedBalance.multipliedBy(await this.contract.slashableProportionPPM.callAsync()).dividedBy("1000000");
 
-        if (approval.plus(currentBalance).lt(listing.stakedBalance)) {
-            await this.treasury.approveTreasury(listing.stakedBalance.minus(currentBalance));
+        if (approval.plus(currentBalance).lt(challengeableBalance)) {
+            await this.treasury.approveTreasury(challengeableBalance.minus(currentBalance));
         }
 
         return contract.challengeListing.awaitTransactionSuccessAsync(_pubKey, _details);

--- a/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
+++ b/packages/kosu-wrapper-enhancements/src/ValidatorRegistry.ts
@@ -260,7 +260,9 @@ export class ValidatorRegistry {
         const listing: Listing = await this.getListing(_pubKey);
         const approval: BigNumber = await this.treasury.treasuryAllowance();
         const currentBalance: BigNumber = await this.treasury.currentBalance(this.coinbase);
-        const challengeableBalance: BigNumber = listing.stakedBalance.multipliedBy(await this.contract.slashableProportionPPM.callAsync()).dividedBy("1000000");
+        const challengeableBalance: BigNumber = listing.stakedBalance
+            .multipliedBy(await this.contract.slashableProportionPPM.callAsync())
+            .dividedBy("1000000");
 
         if (approval.plus(currentBalance).lt(challengeableBalance)) {
             await this.treasury.approveTreasury(challengeableBalance.minus(currentBalance));

--- a/packages/kosu-wrapper-enhancements/test/validator_registry_test.ts
+++ b/packages/kosu-wrapper-enhancements/test/validator_registry_test.ts
@@ -18,7 +18,7 @@ describe("ValidatorRegistry", () => {
 
         const resp = await validatorRegistry.registerListing(
             pubKey,
-            await validatorRegistry.minimumBalance(),
+            await validatorRegistry.minimumStake(),
             TestValues.zero,
             "string",
         );


### PR DESCRIPTION
## Background

The current `ValidatorRegistry` implementation allows listing applicants to specify a `stake` that must be greater than or equal to a `minimumBalance` (currently specified as `500 ether` units of KOSU ).

This `minimumBalance`, as well as any number of tokens included above this amount are available to be slashed in the event of a successful challenge, and is used to set the validator's vote power (if accepted) on the Kosu network.

The power is calculated as `floor(stake / 1e18)` so the "unit" amount of Kosu is used to set vote power, as opposed to the "base unit" amount.

## Proposal overview
_Parameter names not final._

This proposal introduces two "top-level" changes. First, it introduces a new parameter, `slashableProportion` that is the fraction of a listings stake that is available to slashing in the case of a successful challenge. Second, it changes `minimumBalance` to `minimumStake` which effectively is the same thing, except `minimumStake` does not refer to the "slashable stake" (equal to `slashableProportion` * `stakedBalance`) but rather the full stake.

By defining a `minimumStake` and a `slashableProportion`, we implicitly define the minimum slashable stake as `(minimumStake * slashableProportion)`.

A challenge against a proposal or active listing must put up an amount of tokens equal to `(listing.stake * slashableProportion)`.

Additionally, the validators vote power will become the unit value of their slashable stake, rather than the unit value of their full stake (calculated in the network clients based on the full stake and the `slashableProportion` parameter).

This new `slashableProportion` parameter will be emitted within an event log during contract system deployment (prior to snapshot), and will be set in the genesis file of Kosu network's so the clients may perform the calculation to set each validator's power. If the parameter is updated post-deployment (and post-snapshot) an event must be emitted allowing the validators maintaining the peg-zone to update this consensus parameter.

## Specification
The changes this proposal requires are outlined in more detail here. Primarily, the changes entail:
1. Adding necessary parameters and logic to the contract system
1. Adding a new event type to indicate the value of `slashableProportion`
1. Adding a new consensus parameter in `kosud`
1. Adding the ability to set the new consensus parameter from snapshots in `gen-kosu`
1. Adding a new witness transaction type to update parameters changed in the contract system
1. Adding the necessary power calculation logic in `kosud` based on `slashableProportion`
1. ???

### Contract system
- `slashableProportion`
  - add paremeter to constructor(unless we hard code it)
    - This proportion can not be stored as a decimal. The desired precision must be determined and the value be stored as a parts per the corresponding base.  (The numerator of a fractional representation.)
    - Name may be updated based on decision.
    - `stakeholderCut` should have the same considerations (currently percent) and renaming as above (if any)
  - SlashablePortionUpdated event
    - Add to constructor
    - Add block to config update function and emit this event.
- `minimumBalance`
  - Rename to `minimumStake`
- Listing.stakedBalance
  - The usages need to be updated on a one by one basis.  Some calculations may need to be `minimumStake * slashableProportion / base`
  - Challenge and challenge resolution logic needs to be reviewed and updated to account for listings getting the balance safe from a challenge.

### Network client
```
@todo
```
`slashableProportion`  event decoder

### Typescript libraries
`slashableProportion` event decoder


## Considerations
```
@todo
```